### PR TITLE
feat: 提供中文界面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+*.db-*
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
 # ImageViewer
+
+该仓库包含用于构建和维护超大本地媒体库索引的工具。索引数据存储在 SQLite 中，因此在后续启动 ImageViewer 界面时，无需每次都重新扫描文件系统，就能几乎即时打开拥有数百万条目的目录树。
+
+## 功能亮点
+
+- 使用高效的 `os.scandir` 原语的多线程目录爬虫。
+- 增量更新：已存在于索引中的条目会被复用，当文件消失时会被移除。
+- 可配置的批量大小，用于平衡内存占用与写入性能。
+- 提供命令行界面以构建和刷新索引。
+- 基于目录名称关键词的自动标签功能，便于进行语义分类。
+- 预置中文界面的菜单栏配置，方便前端直接加载使用。
+- Electron 图形界面完整中文化，提供目录选择、标签筛选与离线缓存能力。
+
+## 使用方法
+
+推荐先创建虚拟环境（可选），并以开发模式安装项目及其依赖：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+随后构建索引：
+
+```bash
+python -m image_viewer.indexer /path/to/your/library --database media_index.db --workers 8
+```
+
+后续运行时，仅扫描新增或发生变化的文件，因此指向同一目录即可快速刷新索引。
+
+使用 `--min-tag-frequency` 可以控制关键词至少在多少个目录名称中出现后才会升级为标签。例如，以下命令要求某个关键词至少在三个目录名称中出现一次，才会生成对应标签：
+
+```bash
+python -m image_viewer.indexer /path/to/your/library --min-tag-frequency 3
+```
+
+### 中文图形界面
+
+`app/` 目录包含已经翻译好的 Electron 前端。界面中所有标题、按钮、空状态提示与标签名称均为中文，可与上方的索引器配合使用：
+
+```bash
+cd app
+npm install
+npm start
+```
+
+界面功能简介：
+
+- **选择目录：** 点击右上角按钮调用系统对话框，新增的目录会在侧栏展示，并写入本地缓存。
+- **自动标签：** 当多个目录包含相同关键词时，会自动生成中文标签，点击即可筛选。
+- **离线模式：** 如果未启动 Electron 主进程提供的 IPC 接口，界面会使用浏览器的 LocalStorage 作为后备，仍可体验中文界面。
+
+### 菜单栏本地化
+
+`image_viewer.menu` 模块提供了 `build_default_menu()` 函数，可生成一份已经
+翻译成中文的菜单栏结构。前端（例如 Electron 或桌面应用）可以直接将其
+序列化为 JSON，填充到应用的菜单系统中：
+
+```python
+from image_viewer.menu import build_default_menu
+
+menu_definition = [item.to_dict() for item in build_default_menu()]
+# 将 menu_definition 传入前端或写入配置文件即可。所有菜单标题、命令名称
+# 与快捷键提示均已是中文描述。
+```
+
+### 以代码方式调用
+
+```python
+from image_viewer.indexer import DirectoryIndexer
+
+with DirectoryIndexer("/path/to/library", "media_index.db") as indexer:
+    indexer.build_index(max_workers=8, min_tag_frequency=2)
+    for entry in indexer.list_directory("season1"):
+        print(entry.path, entry.size)
+
+    for tag in indexer.list_tags():
+        print(tag.display_name, tag.match_count)
+
+    beach_folders = indexer.list_directories_by_tag("beach")
+    print("海滩主题目录:", [entry.path for entry in beach_folders])
+```
+
+## 目录分类规划与可行性分析
+
+自动标签系统会依据相似的目录名称对文件夹分组，从而可以通过诸如 `Vacation` 或 `Family` 的语义标签来浏览大型媒体库。该实现完全依赖 SQLite 索引中已存储的目录名称，因此即使面对数 TB 的资源集合，仍然十分轻量。
+
+- **分词策略：** 将目录名称拆分为字母和数字组成的 token，忽略标点符号。长度小于两个字符的 token 会被丢弃，以避免如 `S`、`X` 等缩写带来的噪声。
+- **共享关键词检测：** 只有当某个 token 至少出现在 `min_tag_frequency` 个不同目录中时，才会被提升为标签。该阈值既能避免一次性目录名称污染标签列表，又能凸显重复出现的主题。
+- **标签元数据：** 会同时存储规范化的 token 和便于阅读的展示字符串。标签与目录之间的关联被持久化，以便界面在筛选标签对应目录时能够即时返回结果。
+- **可行性：** 标签构建复用现有的目录索引，并在写入 SQLite 之前于内存中批处理完成。该流程的复杂度与目录数量（而非文件数量）成正比，且分词仅是针对每个目录名称执行一次正则表达式匹配，因此对索引流程影响极小。外键约束可以确保在更新或删除条目时，标签关联保持同步。
+
+该设计为未来的扩展留出了空间，例如按不同语言自定义分词器或允许用户定义同义词，而无需修改核心数据模型。
+
+## 测试
+
+运行自动化检查：
+
+```bash
+pytest
+```

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": ["warn", {"args": "none"}],
+    "prefer-const": "warn"
+  }
+}

--- a/app/main.js
+++ b/app/main.js
@@ -1,0 +1,179 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+const STORE_FILE = () => path.join(app.getPath('userData'), 'directories.json');
+const MIN_TAG_COUNT = 2;
+
+/**
+ * @returns {{directories: Array<{id: string; name: string; path: string; createdAt: string}>}}
+ */
+function loadStore() {
+  const file = STORE_FILE();
+  try {
+    const content = fs.readFileSync(file, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    return { directories: [] };
+  }
+}
+
+/**
+ * @param {{directories: Array}} data
+ */
+function saveStore(data) {
+  const file = STORE_FILE();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+/**
+ * @param {string} name
+ * @returns {Set<string>}
+ */
+function extractKeywords(name) {
+  const keywordPattern = /[\p{Script=Han}\p{L}\p{N}]+/gu;
+  const tokens = name.match(keywordPattern) || [];
+  return new Set(
+    tokens
+      .map((token) => token.trim().toLowerCase())
+      .filter((token) => token.length > 1)
+  );
+}
+
+/**
+ * @param {ReturnType<typeof loadStore>['directories']} directories
+ */
+function buildTagIndex(directories) {
+  /** @type {Map<string, {displayName: string; count: number; ids: string[]}>} */
+  const index = new Map();
+
+  for (const entry of directories) {
+    for (const keyword of extractKeywords(entry.name)) {
+      const bucket = index.get(keyword) ?? {
+        displayName: humanizeKeyword(keyword),
+        count: 0,
+        ids: [],
+      };
+      if (!bucket.ids.includes(entry.id)) {
+        bucket.ids.push(entry.id);
+        bucket.count += 1;
+      }
+      index.set(keyword, bucket);
+    }
+  }
+
+  for (const [key, bucket] of Array.from(index.entries())) {
+    if (bucket.count < MIN_TAG_COUNT) {
+      index.delete(key);
+    }
+  }
+
+  return index;
+}
+
+/**
+ * @param {string} keyword
+ */
+function humanizeKeyword(keyword) {
+  if (/^[\p{Script=Han}]+$/u.test(keyword)) {
+    return keyword;
+  }
+  return keyword.replace(/(^|\s|[-_])(\p{L})/gu, (_, prefix, letter) => `${prefix}${letter.toUpperCase()}`);
+}
+
+/**
+ * @param {ReturnType<typeof loadStore>} store
+ * @param {string} directoryPath
+ */
+function upsertDirectory(store, directoryPath) {
+  const normalizedPath = path.resolve(directoryPath);
+  const name = path.basename(normalizedPath);
+  const existingIndex = store.directories.findIndex((item) => item.path === normalizedPath);
+  const entry = {
+    id: normalizedPath,
+    name,
+    path: normalizedPath,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (existingIndex >= 0) {
+    store.directories[existingIndex] = entry;
+  } else {
+    store.directories.push(entry);
+  }
+}
+
+function setupIpc(store) {
+  ipcMain.handle('directories:list', async () => store.directories);
+
+  ipcMain.handle('directories:select', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ['openDirectory'] });
+    if (canceled || filePaths.length === 0) {
+      return { canceled: true };
+    }
+
+    upsertDirectory(store, filePaths[0]);
+    saveStore(store);
+    return { canceled: false, directories: store.directories };
+  });
+
+  ipcMain.handle('directories:remove', async (_event, directoryId) => {
+    const index = store.directories.findIndex((item) => item.id === directoryId);
+    if (index >= 0) {
+      store.directories.splice(index, 1);
+      saveStore(store);
+    }
+    return store.directories;
+  });
+
+  ipcMain.handle('tags:list', async () => {
+    const index = buildTagIndex(store.directories);
+    return Array.from(index.entries()).map(([key, value]) => ({
+      id: key,
+      displayName: value.displayName,
+      count: value.count,
+    }));
+  });
+
+  ipcMain.handle('tags:directories', async (_event, tagId) => {
+    const index = buildTagIndex(store.directories);
+    const bucket = index.get(tagId);
+    if (!bucket) {
+      return [];
+    }
+    return store.directories.filter((entry) => bucket.ids.includes(entry.id));
+  });
+}
+
+function createWindow(store) {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 720,
+    minWidth: 960,
+    minHeight: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  win.loadFile(path.join(__dirname, 'src/index.html'));
+}
+
+app.whenReady().then(() => {
+  const store = loadStore();
+  setupIpc(store);
+  createWindow(store);
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow(store);
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "local-media-explorer",
+  "version": "0.2.0",
+  "description": "Electron shell for the ImageViewer 索引工具，提供完整中文界面。",
+  "main": "main.js",
+  "private": true,
+  "scripts": {
+    "start": "electron .",
+    "lint": "eslint --ext .js,.ts src"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "eslint": "^8.57.0"
+  },
+  "dependencies": {
+    "@primer/css": "^17.0.1"
+  }
+}

--- a/app/preload.js
+++ b/app/preload.js
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('mediaAPI', {
+  listDirectories: () => ipcRenderer.invoke('directories:list'),
+  selectDirectory: () => ipcRenderer.invoke('directories:select'),
+  removeDirectory: (directoryId) => ipcRenderer.invoke('directories:remove', directoryId),
+  listTags: () => ipcRenderer.invoke('tags:list'),
+  filterByTag: (tagId) => ipcRenderer.invoke('tags:directories', tagId),
+});

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>本地媒体浏览器</title>
+    <link rel="stylesheet" href="https://unpkg.com/@primer/css/dist/primer.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="branding">
+          <h1 class="app-title">本地媒体浏览器</h1>
+          <p class="app-subtitle">快速筛选和浏览超大媒体资料库</p>
+        </div>
+        <button id="select-directory" class="btn btn-primary">
+          选择目录
+        </button>
+      </header>
+      <main class="app-main">
+        <aside class="sidebar">
+          <div class="panel">
+            <div class="panel-header">
+              <h2 class="panel-title">已保存的目录</h2>
+              <button id="clear-selection" class="btn btn-sm btn-invisible">清除筛选</button>
+            </div>
+            <ul id="directory-list" class="directory-list"></ul>
+          </div>
+          <div class="panel">
+            <div class="panel-header">
+              <h3 class="panel-title">标签</h3>
+              <span id="tag-summary" class="panel-meta"></span>
+            </div>
+            <div id="tag-list" class="tag-list"></div>
+          </div>
+        </aside>
+        <section class="content">
+          <div class="content-header">
+            <h2 id="content-title">媒体</h2>
+            <span id="content-meta" class="content-meta">请选择标签或目录开始浏览</span>
+          </div>
+          <div id="directory-detail" class="directory-detail empty">
+            <div class="empty-state">
+              <h3>尚未选择目录</h3>
+              <p>点击左上角的“选择目录”按钮，即可将常用文件夹加入到列表中。</p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+    <script type="module" src="renderer.js"></script>
+  </body>
+</html>

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -1,0 +1,314 @@
+const storageKey = 'local-media-explorer.directories';
+
+const state = {
+  directories: [],
+  tags: [],
+  activeDirectoryId: null,
+  activeTagId: null,
+};
+
+const directoryListEl = document.getElementById('directory-list');
+const tagListEl = document.getElementById('tag-list');
+const tagSummaryEl = document.getElementById('tag-summary');
+const contentTitleEl = document.getElementById('content-title');
+const contentMetaEl = document.getElementById('content-meta');
+const directoryDetailEl = document.getElementById('directory-detail');
+const clearSelectionBtn = document.getElementById('clear-selection');
+
+function loadFromLocalStorage() {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    return [];
+  } catch (error) {
+    console.warn('读取本地目录缓存失败', error);
+    return [];
+  }
+}
+
+function persistToLocalStorage() {
+  if (window.mediaAPI?.listDirectories) {
+    return;
+  }
+  localStorage.setItem(storageKey, JSON.stringify(state.directories));
+}
+
+function extractKeywords(name) {
+  const pattern = /[\p{Script=Han}\p{L}\p{N}]+/gu;
+  const matches = name.match(pattern) || [];
+  return Array.from(
+    new Set(
+      matches
+        .map((token) => token.trim().toLowerCase())
+        .filter((token) => token.length > 1)
+    )
+  );
+}
+
+function humanizeKeyword(keyword) {
+  if (/^[\p{Script=Han}]+$/u.test(keyword)) {
+    return keyword;
+  }
+  return keyword.replace(/(^|\s|[-_])(\p{L})/gu, (_, prefix, letter) => `${prefix}${letter.toUpperCase()}`);
+}
+
+function buildLocalTags() {
+  const buckets = new Map();
+  for (const directory of state.directories) {
+    for (const keyword of extractKeywords(directory.name)) {
+      const bucket = buckets.get(keyword) ?? { id: keyword, displayName: humanizeKeyword(keyword), count: 0 };
+      bucket.count += 1;
+      buckets.set(keyword, bucket);
+    }
+  }
+  return Array.from(buckets.values()).filter((item) => item.count >= 2);
+}
+
+function renderDirectories() {
+  directoryListEl.innerHTML = '';
+  if (state.directories.length === 0) {
+    directoryListEl.innerHTML = '<li class="empty-hint">暂无目录，请先选择一个文件夹。</li>';
+    return;
+  }
+
+  for (const entry of state.directories) {
+    const listItem = document.createElement('li');
+    listItem.className = 'directory-item';
+    if (state.activeDirectoryId === entry.id) {
+      listItem.classList.add('active');
+    }
+
+    const title = document.createElement('h4');
+    title.textContent = entry.name;
+
+    const subtitle = document.createElement('span');
+    subtitle.textContent = entry.path;
+
+    listItem.appendChild(title);
+    listItem.appendChild(subtitle);
+
+    listItem.addEventListener('click', () => {
+      state.activeDirectoryId = entry.id;
+      state.activeTagId = null;
+      renderDirectories();
+      renderTags();
+      void renderDetail();
+    });
+
+    directoryListEl.appendChild(listItem);
+  }
+}
+
+function renderTags() {
+  tagListEl.innerHTML = '';
+  tagSummaryEl.textContent = state.tags.length > 0 ? `共 ${state.tags.length} 个标签` : '暂无标签';
+
+  if (state.tags.length === 0) {
+    const emptyHint = document.createElement('span');
+    emptyHint.className = 'empty-hint';
+    emptyHint.textContent = '当多个目录名称包含相同关键词时，这里会自动生成标签。';
+    tagListEl.appendChild(emptyHint);
+    return;
+  }
+
+  for (const tag of state.tags) {
+    const pill = document.createElement('button');
+    pill.className = 'tag-pill btn-invisible';
+    pill.type = 'button';
+    if (state.activeTagId === tag.id) {
+      pill.classList.add('active');
+    }
+    pill.textContent = `${tag.displayName} (${tag.count})`;
+    pill.addEventListener('click', () => {
+      state.activeTagId = tag.id;
+      state.activeDirectoryId = null;
+      renderDirectories();
+      renderTags();
+      void renderDetail();
+    });
+    tagListEl.appendChild(pill);
+  }
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '未知时间';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+async function renderDetail() {
+  const hasSelection = Boolean(state.activeDirectoryId || state.activeTagId);
+  directoryDetailEl.classList.toggle('empty', !hasSelection);
+
+  if (!hasSelection) {
+    contentTitleEl.textContent = '媒体';
+    contentMetaEl.textContent = '请选择标签或目录开始浏览';
+    directoryDetailEl.innerHTML = `
+      <div class="empty-state">
+        <h3>尚未选择目录</h3>
+        <p>左侧列表会显示已保存的目录，并自动按标签分类。</p>
+      </div>
+    `;
+    return;
+  }
+
+  if (state.activeDirectoryId) {
+    const entry = state.directories.find((item) => item.id === state.activeDirectoryId);
+    if (!entry) {
+      state.activeDirectoryId = null;
+      await renderDetail();
+      return;
+    }
+    contentTitleEl.textContent = entry.name;
+    contentMetaEl.textContent = `路径：${entry.path}`;
+    directoryDetailEl.innerHTML = `
+      <div class="entry-card">
+        <div class="path">${entry.path}</div>
+        <div class="meta">
+          <span>加入时间：${formatDate(entry.createdAt)}</span>
+        </div>
+        <div class="meta">
+          <span>自动标签：${extractKeywords(entry.name).map(humanizeKeyword).join('、') || '无'}</span>
+        </div>
+      </div>
+    `;
+    return;
+  }
+
+  if (state.activeTagId) {
+    const tag = state.tags.find((item) => item.id === state.activeTagId);
+    contentTitleEl.textContent = `标签：${tag ? tag.displayName : state.activeTagId}`;
+    const directories = await getDirectoriesByTag(state.activeTagId);
+    contentMetaEl.textContent = `共 ${directories.length} 个目录匹配`;
+    if (directories.length === 0) {
+      directoryDetailEl.innerHTML = `
+        <div class="empty-state">
+          <h3>暂无匹配目录</h3>
+          <p>尝试选择其他标签，或添加更多包含该关键词的目录。</p>
+        </div>
+      `;
+      return;
+    }
+
+    const container = document.createElement('div');
+    container.className = 'entry-grid';
+
+    for (const directory of directories) {
+      const card = document.createElement('div');
+      card.className = 'entry-card';
+
+      const name = document.createElement('h4');
+      name.textContent = directory.name;
+
+      const pathLabel = document.createElement('div');
+      pathLabel.className = 'path';
+      pathLabel.textContent = directory.path;
+
+      const meta = document.createElement('div');
+      meta.className = 'meta';
+      meta.innerHTML = `<span>加入时间：${formatDate(directory.createdAt)}</span>`;
+
+      card.appendChild(name);
+      card.appendChild(pathLabel);
+      card.appendChild(meta);
+      container.appendChild(card);
+    }
+
+    directoryDetailEl.innerHTML = '';
+    directoryDetailEl.appendChild(container);
+  }
+}
+
+async function getDirectoriesByTag(tagId) {
+  if (window.mediaAPI?.filterByTag) {
+    try {
+      const result = await window.mediaAPI.filterByTag(tagId);
+      if (Array.isArray(result) && result.length > 0) {
+        return result;
+      }
+    } catch (error) {
+      console.warn('读取标签关联目录失败，改用本地计算', error);
+    }
+  }
+  return state.directories.filter((entry) => extractKeywords(entry.name).includes(tagId));
+}
+
+async function refreshState() {
+  if (window.mediaAPI?.listDirectories) {
+    state.directories = await window.mediaAPI.listDirectories();
+  } else {
+    state.directories = loadFromLocalStorage();
+  }
+  if (window.mediaAPI?.listTags) {
+    state.tags = await window.mediaAPI.listTags();
+  } else {
+    state.tags = buildLocalTags();
+  }
+  renderDirectories();
+  renderTags();
+  void renderDetail();
+}
+
+async function handleSelectDirectory() {
+  if (window.mediaAPI?.selectDirectory) {
+    const result = await window.mediaAPI.selectDirectory();
+    if (result && !result.canceled) {
+      state.directories = result.directories ?? (await window.mediaAPI.listDirectories());
+      persistToLocalStorage();
+      state.tags = window.mediaAPI.listTags ? await window.mediaAPI.listTags() : buildLocalTags();
+      renderDirectories();
+      renderTags();
+      void renderDetail();
+    }
+    return;
+  }
+
+  const manualPath = window.prompt('请输入要添加的目录路径：');
+  if (!manualPath) {
+    return;
+  }
+  const normalized = manualPath.trim();
+  if (!normalized) {
+    return;
+  }
+  const entry = {
+    id: normalized,
+    name: normalized.split(/[/\\]/).filter(Boolean).pop() || normalized,
+    path: normalized,
+    createdAt: new Date().toISOString(),
+  };
+  const existingIndex = state.directories.findIndex((item) => item.id === entry.id);
+  if (existingIndex >= 0) {
+    state.directories[existingIndex] = entry;
+  } else {
+    state.directories.push(entry);
+  }
+  state.tags = buildLocalTags();
+  persistToLocalStorage();
+  renderDirectories();
+  renderTags();
+  void renderDetail();
+}
+
+clearSelectionBtn.addEventListener('click', () => {
+  state.activeDirectoryId = null;
+  state.activeTagId = null;
+  renderDirectories();
+  renderTags();
+  void renderDetail();
+});
+
+document.getElementById('select-directory').addEventListener('click', handleSelectDirectory);
+
+refreshState();

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,0 +1,240 @@
+:root {
+  color-scheme: light dark;
+  --sidebar-width: 320px;
+  --background: var(--color-canvas-default, #ffffff);
+  --border-color: var(--color-border-muted, #d0d7de);
+  --shadow-color: rgba(15, 23, 42, 0.08);
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  background: var(--background);
+  color: var(--color-fg-default, #1f2328);
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.75rem;
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 4px 16px var(--shadow-color);
+  background: linear-gradient(135deg, rgba(9, 132, 227, 0.1), rgba(116, 185, 255, 0.05));
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.app-subtitle {
+  margin: 0.125rem 0 0;
+  color: var(--color-fg-muted, #57606a);
+}
+
+.app-main {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  padding: 1.5rem;
+  border-right: 1px solid var(--border-color);
+  overflow-y: auto;
+  background: var(--color-canvas-subtle, #f6f8fa);
+}
+
+.panel + .panel {
+  margin-top: 1.5rem;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.panel-meta {
+  font-size: 0.875rem;
+  color: var(--color-fg-muted, #57606a);
+}
+
+.directory-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.directory-item {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  background: var(--color-canvas-default, #ffffff);
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
+}
+
+.directory-item:hover {
+  border-color: rgba(9, 132, 227, 0.4);
+  transform: translateY(-1px);
+}
+
+.directory-item.active {
+  border-color: rgba(9, 132, 227, 0.7);
+  box-shadow: 0 4px 16px rgba(9, 132, 227, 0.15);
+}
+
+.directory-item h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.directory-item span {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.875rem;
+  color: var(--color-fg-muted, #57606a);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(9, 132, 227, 0.4);
+  background: rgba(9, 132, 227, 0.12);
+  color: #0a60c3;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.tag-pill:hover,
+.tag-pill.active {
+  background: rgba(9, 132, 227, 0.22);
+  color: #07408a;
+  transform: translateY(-1px);
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.75rem 2rem;
+  overflow: hidden;
+}
+
+.content-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.content-header h2 {
+  margin: 0;
+}
+
+.content-meta {
+  color: var(--color-fg-muted, #57606a);
+}
+
+.directory-detail {
+  flex: 1;
+  margin-top: 1.5rem;
+  border: 1px dashed var(--border-color);
+  border-radius: 16px;
+  padding: 1.5rem;
+  overflow-y: auto;
+  background: var(--color-canvas-default, #ffffff);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.02);
+}
+
+.directory-detail.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--color-fg-muted, #57606a);
+}
+
+.entry-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.entry-card {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  background: var(--color-canvas-subtle, #f6f8fa);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.entry-card .path {
+  font-size: 0.875rem;
+  color: var(--color-fg-muted, #57606a);
+  word-break: break-all;
+}
+
+.entry-card .meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--color-fg-subtle, #6e7781);
+}
+
+@media (max-width: 1024px) {
+  :root {
+    --sidebar-width: 280px;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .content-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "imageviewer"
+version = "0.1.0"
+description = "Local media indexer for fast browsing"
+authors = [{name = "ImageViewer Team"}]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/image_viewer/indexer.py
+++ b/src/image_viewer/indexer.py
@@ -1,0 +1,496 @@
+"""ImageViewer 项目的目录索引工具。
+
+该模块提供 :class:`DirectoryIndexer`，可用于遍历超大的目录结构，并将轻量级索引持久化到 SQLite 数据库中。借助该索引，在后续运行时无需
+再次进行耗时的 IO 密集型目录扫描，就能快速打开容量高达数 TB 的媒体库。
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import queue
+import re
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class IndexEntry:
+    """索引中存储的单个文件或目录条目。"""
+
+    path: str
+    parent: str
+    is_dir: bool
+    size: Optional[int]
+    mtime: float
+
+
+@dataclass(slots=True)
+class TagSummary:
+    """自动生成的目录标签概览。"""
+
+    name: str
+    display_name: str
+    match_count: int
+
+
+class DirectoryIndexer:
+    """利用 SQLite 增量维护文件系统索引。
+
+    Parameters
+    ----------
+    root_path:
+        需要建立索引的根目录。
+    db_path:
+        存储索引的 SQLite 数据库文件路径。
+    follow_symlinks:
+        是否在遍历时跟随符号链接。默认为 ``False``，以避免符号链接形成循环时产生无限递归。
+    """
+
+    def __init__(
+        self,
+        root_path: os.PathLike[str] | str,
+        db_path: os.PathLike[str] | str,
+        *,
+        follow_symlinks: bool = False,
+    ) -> None:
+        self.root_path = Path(root_path).resolve()
+        self.db_path = Path(db_path).resolve()
+        self.follow_symlinks = follow_symlinks
+        wal = self.db_path.with_name(f"{self.db_path.name}-wal")
+        shm = self.db_path.with_name(f"{self.db_path.name}-shm")
+        self._ignored_files = {
+            self.db_path.resolve(),
+            wal.resolve(),
+            shm.resolve(),
+        }
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA temp_store=MEMORY")
+        self._conn.execute("PRAGMA locking_mode=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._db_lock = threading.Lock()
+        self._ensure_schema()
+        LOGGER.debug("索引器已初始化：%s", self.root_path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build_index(
+        self,
+        *,
+        max_workers: Optional[int] = None,
+        batch_size: int = 512,
+        min_tag_frequency: int = 2,
+    ) -> None:
+        """遍历文件系统并更新磁盘上的索引。
+
+        该方法可以反复调用。再次执行时，只会写入新增或已修改的条目，并移除已不存在的文件。繁重的扫描工作会分配给多个工作线程，因而
+        能够高效处理超大的目录树（例如超过 2TB）。
+
+        Parameters
+        ----------
+        max_workers:
+            遍历目录时使用的工作线程数量。若未指定，则根据 ``os.cpu_count()`` 推导。
+        batch_size:
+            在批量写入 SQLite 之前缓冲的 :class:`IndexEntry` 条目数量。批量越大，提交开销越小，但内存占用越高。
+        """
+
+        max_workers = max_workers or max(os.cpu_count() or 1, 4)
+        batch_size = max(batch_size, 32)
+        min_tag_frequency = max(1, min_tag_frequency)
+
+        self._reset_seen_flags()
+        self._upsert_entries([self._create_root_entry()])
+
+        dir_queue: "queue.Queue[tuple[Path, str]]" = queue.Queue()
+        result_queue: "queue.Queue[Sequence[IndexEntry] | object]" = queue.Queue()
+        sentinel = object()
+
+        def worker() -> None:
+            while True:
+                item = dir_queue.get()
+                try:
+                    if item is sentinel:
+                        return
+                    abs_path, rel_path = item
+                    entries, sub_dirs = self._scan_directory(abs_path, rel_path)
+                    if entries:
+                        result_queue.put(entries)
+                    for child_abs, child_rel in sub_dirs:
+                        dir_queue.put((child_abs, child_rel))
+                finally:
+                    dir_queue.task_done()
+
+        def writer() -> None:
+            buffer: List[IndexEntry] = []
+            while True:
+                item = result_queue.get()
+                try:
+                    if item is sentinel:
+                        break
+                    buffer.extend(item)
+                    if len(buffer) >= batch_size:
+                        self._upsert_entries(buffer)
+                        buffer.clear()
+                finally:
+                    result_queue.task_done()
+            if buffer:
+                self._upsert_entries(buffer)
+
+        workers = [threading.Thread(target=worker, daemon=True) for _ in range(max_workers)]
+        for thread in workers:
+            thread.start()
+
+        writer_thread = threading.Thread(target=writer, daemon=True)
+        writer_thread.start()
+
+        dir_queue.put((self.root_path, "."))
+
+        dir_queue.join()
+        result_queue.join()
+
+        result_queue.put(sentinel)
+        writer_thread.join()
+
+        for _ in workers:
+            dir_queue.put(sentinel)
+        for thread in workers:
+            thread.join()
+
+        self._remove_unseen_entries()
+        self._rebuild_tags(min_tag_frequency=min_tag_frequency)
+        LOGGER.info("%s 的索引构建完成", self.root_path)
+
+    def list_directory(self, relative_path: str = ".") -> List[IndexEntry]:
+        """从索引中返回指定目录的内容。
+
+        Parameters
+        ----------
+        relative_path:
+            位于索引根目录下的相对路径，例如 ``"."`` 表示根目录，``"season1"`` 表示某个子目录。
+        """
+
+        with self._db_lock:
+            cur = self._conn.execute(
+                """
+                SELECT path, parent, is_dir, size, mtime
+                FROM entries
+                WHERE parent = ?
+                ORDER BY is_dir DESC, path
+                """,
+                (relative_path,),
+            )
+            rows = cur.fetchall()
+        return [
+            IndexEntry(path=row[0], parent=row[1], is_dir=bool(row[2]), size=row[3], mtime=row[4])
+            for row in rows
+        ]
+
+    def iter_all(self) -> Iterator[IndexEntry]:
+        """遍历索引中存储的所有条目。"""
+
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT path, parent, is_dir, size, mtime FROM entries ORDER BY path"
+            )
+            rows = cur.fetchall()
+        for row in rows:
+            yield IndexEntry(path=row[0], parent=row[1], is_dir=bool(row[2]), size=row[3], mtime=row[4])
+
+    def list_tags(self) -> List[TagSummary]:
+        """返回自动生成的标签及其匹配数量。"""
+
+        with self._db_lock:
+            cur = self._conn.execute(
+                """
+                SELECT tags.name, tags.display_name, COUNT(entry_tags.entry_path) as count
+                FROM tags
+                JOIN entry_tags ON entry_tags.tag_name = tags.name
+                GROUP BY tags.name, tags.display_name
+                ORDER BY count DESC, tags.display_name
+                """
+            )
+            rows = cur.fetchall()
+        return [TagSummary(name=row[0], display_name=row[1], match_count=row[2]) for row in rows]
+
+    def list_directories_by_tag(self, tag_name: str) -> List[IndexEntry]:
+        """返回与指定标签匹配的目录。"""
+
+        with self._db_lock:
+            cur = self._conn.execute(
+                """
+                SELECT e.path, e.parent, e.is_dir, e.size, e.mtime
+                FROM entries e
+                JOIN entry_tags et ON et.entry_path = e.path
+                WHERE et.tag_name = ?
+                ORDER BY e.path
+                """,
+                (tag_name,),
+            )
+            rows = cur.fetchall()
+        return [
+            IndexEntry(path=row[0], parent=row[1], is_dir=bool(row[2]), size=row[3], mtime=row[4])
+            for row in rows
+        ]
+
+    def close(self) -> None:
+        """关闭底层 SQLite 连接。"""
+
+        if self._conn is not None:
+            self._conn.close()
+
+    def __enter__(self) -> "DirectoryIndexer":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_schema(self) -> None:
+        with self._db_lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS entries (
+                    path TEXT PRIMARY KEY,
+                    parent TEXT,
+                    is_dir INTEGER NOT NULL,
+                    size INTEGER,
+                    mtime REAL NOT NULL,
+                    seen INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_entries_parent ON entries(parent)"
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tags (
+                    name TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS entry_tags (
+                    entry_path TEXT NOT NULL,
+                    tag_name TEXT NOT NULL,
+                    PRIMARY KEY (entry_path, tag_name),
+                    FOREIGN KEY (entry_path) REFERENCES entries(path) ON DELETE CASCADE,
+                    FOREIGN KEY (tag_name) REFERENCES tags(name) ON DELETE CASCADE
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_entry_tags_tag ON entry_tags(tag_name)"
+            )
+
+    def _reset_seen_flags(self) -> None:
+        with self._db_lock:
+            self._conn.execute("UPDATE entries SET seen = 0")
+            self._conn.commit()
+
+    def _remove_unseen_entries(self) -> None:
+        with self._db_lock:
+            self._conn.execute("DELETE FROM entries WHERE seen = 0")
+            self._conn.commit()
+
+    def _upsert_entries(self, entries: Sequence[IndexEntry]) -> None:
+        if not entries:
+            return
+        rows = [
+            (
+                entry.path,
+                entry.parent,
+                1 if entry.is_dir else 0,
+                entry.size,
+                entry.mtime,
+            )
+            for entry in entries
+        ]
+        with self._db_lock:
+            self._conn.executemany(
+                """
+                INSERT INTO entries(path, parent, is_dir, size, mtime, seen)
+                VALUES(?, ?, ?, ?, ?, 1)
+                ON CONFLICT(path) DO UPDATE SET
+                    parent = excluded.parent,
+                    is_dir = excluded.is_dir,
+                    size = excluded.size,
+                    mtime = excluded.mtime,
+                    seen = 1
+                """,
+                rows,
+            )
+            self._conn.commit()
+
+    def _create_root_entry(self) -> IndexEntry:
+        stat_info = self.root_path.stat()
+        return IndexEntry(path=".", parent="", is_dir=True, size=None, mtime=stat_info.st_mtime)
+
+    def _scan_directory(self, abs_path: Path, rel_path: str) -> Tuple[List[IndexEntry], List[Tuple[Path, str]]]:
+        entries: List[IndexEntry] = []
+        directories: List[Tuple[Path, str]] = []
+        try:
+            with os.scandir(abs_path) as iterator:
+                for dir_entry in iterator:
+                    entry_path = Path(dir_entry.path)
+                    if entry_path.resolve() in self._ignored_files:
+                        continue
+                    if dir_entry.is_symlink() and not self.follow_symlinks:
+                        continue
+                    try:
+                        stat_info = dir_entry.stat(follow_symlinks=self.follow_symlinks)
+                    except (FileNotFoundError, PermissionError, OSError) as error:
+                        LOGGER.warning("无法读取 %s 的元数据：%s", dir_entry.path, error)
+                        continue
+                    is_directory = dir_entry.is_dir(follow_symlinks=self.follow_symlinks)
+                    relative_child = self._to_relative(Path(dir_entry.path))
+                    entry = IndexEntry(
+                        path=relative_child,
+                        parent=rel_path,
+                        is_dir=is_directory,
+                        size=None if is_directory else stat_info.st_size,
+                        mtime=stat_info.st_mtime,
+                    )
+                    entries.append(entry)
+                    if is_directory:
+                        directories.append((Path(dir_entry.path), relative_child))
+        except (FileNotFoundError, PermissionError) as error:
+            LOGGER.warning("无法访问 %s：%s", abs_path, error)
+        return entries, directories
+
+    def _to_relative(self, path: Path) -> str:
+        try:
+            relative = path.resolve().relative_to(self.root_path)
+        except ValueError:
+            # 当路径超出根目录（例如符号链接指向外部）时，退回到绝对路径表示，以免丢失信息。
+            return path.resolve().as_posix()
+        if not relative.parts:
+            return "."
+        return relative.as_posix()
+
+    def _rebuild_tags(self, *, min_tag_frequency: int) -> None:
+        directories: List[str]
+        with self._db_lock:
+            cur = self._conn.execute("SELECT path FROM entries WHERE is_dir = 1")
+            directories = [row[0] for row in cur.fetchall()]
+
+        token_map: Dict[str, Set[str]] = {}
+        for directory in directories:
+            if directory == ".":
+                continue
+            folder_name = Path(directory).name
+            tokens = self._tokenize(folder_name)
+            for token in tokens:
+                token_map.setdefault(token, set()).add(directory)
+
+        filtered = {token: paths for token, paths in token_map.items() if len(paths) >= min_tag_frequency}
+
+        with self._db_lock:
+            self._conn.execute("DELETE FROM entry_tags")
+            self._conn.execute("DELETE FROM tags")
+
+            if filtered:
+                ordered_tokens = sorted(filtered.keys())
+                tag_rows = [
+                    (token, self._format_tag_display(token))
+                    for token in ordered_tokens
+                ]
+                self._conn.executemany(
+                    "INSERT INTO tags(name, display_name) VALUES(?, ?)",
+                    tag_rows,
+                )
+
+                association_rows = [
+                    (directory, token)
+                    for token in ordered_tokens
+                    for directory in sorted(filtered[token])
+                ]
+                self._conn.executemany(
+                    "INSERT INTO entry_tags(entry_path, tag_name) VALUES(?, ?)",
+                    association_rows,
+                )
+
+            self._conn.commit()
+
+    def _tokenize(self, name: str) -> Set[str]:
+        tokens = {match.group(0).lower() for match in re.finditer(r"[0-9A-Za-z]+", name)}
+        return {token for token in tokens if len(token) >= 2}
+
+    def _format_tag_display(self, token: str) -> str:
+        if token.isalpha():
+            return token.capitalize()
+        return token
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="为大型媒体库构建 SQLite 索引")
+    parser.add_argument("root", type=Path, help="需要建立索引的根目录")
+    parser.add_argument(
+        "--database",
+        type=Path,
+        default=Path("media_index.db"),
+        help="生成的 SQLite 数据库存放位置（默认：media_index.db）",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="工作线程数量（默认使用逻辑 CPU 数量）",
+    )
+    parser.add_argument(
+        "--follow-symlinks",
+        action="store_true",
+        help="在索引过程中跟随符号链接",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=512,
+        help="写入磁盘前缓冲的条目数量",
+    )
+    parser.add_argument(
+        "--min-tag-frequency",
+        type=int,
+        default=2,
+        help="某个关键词至少需要匹配多少个目录后才会升级为标签",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="索引过程使用的日志级别",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    with DirectoryIndexer(args.root, args.database, follow_symlinks=args.follow_symlinks) as indexer:
+        indexer.build_index(
+            max_workers=args.workers,
+            batch_size=args.batch_size,
+            min_tag_frequency=args.min_tag_frequency,
+        )
+    LOGGER.info("索引已写入 %s", args.database)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/image_viewer/menu.py
+++ b/src/image_viewer/menu.py
@@ -1,0 +1,112 @@
+"""应用菜单栏的中文化定义。
+
+该模块提供 :func:`build_default_menu`，用于生成 ImageViewer 前端默认
+菜单的数据结构。菜单条目的标签、命令和快捷键均以中文呈现，便于提
+供一致的本地化体验。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass(slots=True)
+class MenuItem:
+    """表示菜单栏中的单个条目。"""
+
+    label: str = ""
+    command: Optional[str] = None
+    role: Optional[str] = None
+    accelerator: Optional[str] = None
+    submenu: List["MenuItem"] = field(default_factory=list)
+    enabled: bool = True
+    is_separator: bool = False
+
+    @classmethod
+    def separator(cls) -> "MenuItem":
+        """创建一个分隔符条目。"""
+
+        return cls(label="", is_separator=True)
+
+    def to_dict(self) -> Dict[str, object]:
+        """将菜单项转换为前端可直接消费的字典结构。"""
+
+        if self.is_separator:
+            return {"type": "separator"}
+
+        data: Dict[str, object] = {"label": self.label}
+        if self.command:
+            data["command"] = self.command
+        if self.role:
+            data["role"] = self.role
+        if self.accelerator:
+            data["accelerator"] = self.accelerator
+        if self.submenu:
+            data["submenu"] = [child.to_dict() for child in self.submenu]
+        if not self.enabled:
+            data["enabled"] = False
+        return data
+
+
+def build_default_menu() -> List[MenuItem]:
+    """返回带有中文标签的默认菜单栏配置。"""
+
+    file_menu = MenuItem(
+        label="文件",
+        submenu=[
+            MenuItem(label="打开目录…", command="open-directory", accelerator="Ctrl+O"),
+            MenuItem(label="刷新索引", command="refresh-index", accelerator="Ctrl+R"),
+            MenuItem.separator(),
+            MenuItem(label="导出标签…", command="export-tags", accelerator="Ctrl+E"),
+            MenuItem.separator(),
+            MenuItem(label="退出", role="quit"),
+        ],
+    )
+
+    edit_menu = MenuItem(
+        label="编辑",
+        submenu=[
+            MenuItem(label="撤销", role="undo", accelerator="Ctrl+Z"),
+            MenuItem(label="重做", role="redo", accelerator="Ctrl+Shift+Z"),
+            MenuItem.separator(),
+            MenuItem(label="剪切", role="cut", accelerator="Ctrl+X"),
+            MenuItem(label="复制", role="copy", accelerator="Ctrl+C"),
+            MenuItem(label="粘贴", role="paste", accelerator="Ctrl+V"),
+            MenuItem(label="全选", role="selectAll", accelerator="Ctrl+A"),
+        ],
+    )
+
+    view_menu = MenuItem(
+        label="视图",
+        submenu=[
+            MenuItem(label="缩略图视图", command="show-thumbnails", accelerator="Ctrl+1"),
+            MenuItem(label="列表视图", command="show-list", accelerator="Ctrl+2"),
+            MenuItem.separator(),
+            MenuItem(label="显示标签面板", command="toggle-tag-panel", accelerator="Ctrl+T"),
+            MenuItem(label="重新加载", role="reload", accelerator="Ctrl+R"),
+            MenuItem(label="切换全屏", role="togglefullscreen", accelerator="F11"),
+        ],
+    )
+
+    window_menu = MenuItem(
+        label="窗口",
+        submenu=[
+            MenuItem(label="最小化", role="minimize"),
+            MenuItem(label="关闭窗口", role="close"),
+        ],
+    )
+
+    help_menu = MenuItem(
+        label="帮助",
+        submenu=[
+            MenuItem(label="查看使用手册", command="open-manual"),
+            MenuItem(label="提交反馈", command="open-feedback"),
+            MenuItem.separator(),
+            MenuItem(label="关于 ImageViewer", command="open-about"),
+        ],
+    )
+
+    return [file_menu, edit_menu, view_menu, window_menu, help_menu]
+
+
+__all__ = ["MenuItem", "build_default_menu"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,89 @@
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from image_viewer.indexer import DirectoryIndexer
+
+
+def create_file(path: Path, content: str = "data") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_initial_index_build(tmp_path: Path) -> None:
+    create_file(tmp_path / "season1" / "episode1.mp4")
+    create_file(tmp_path / "season1" / "episode2.mp4")
+    create_file(tmp_path / "season2" / "episode1.mp4")
+
+    index_path = tmp_path / "index.db"
+    with DirectoryIndexer(tmp_path, index_path) as indexer:
+        indexer.build_index(max_workers=2, batch_size=10)
+        root_entries = indexer.list_directory(".")
+
+    names = sorted(entry.path for entry in root_entries)
+    assert names == ["season1", "season2"]
+
+    with sqlite3.connect(index_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+    # 1 root + 2 folders + 3 files = 6 entries
+    assert count == 6
+
+
+def test_incremental_updates(tmp_path: Path) -> None:
+    season1 = tmp_path / "season1"
+    episode1 = season1 / "episode1.mp4"
+    create_file(episode1, "one")
+
+    index_path = tmp_path / "index.db"
+    with DirectoryIndexer(tmp_path, index_path) as indexer:
+        indexer.build_index(max_workers=2, batch_size=4)
+
+        time.sleep(1.1)  # ensure mtime resolution differences do not hide updates
+        episode1.write_text("updated")
+        create_file(season1 / "episode2.mp4", "two")
+        (tmp_path / "orphan.txt").write_text("orphan")
+        indexer.build_index(max_workers=2, batch_size=4)
+
+        entries = {entry.path for entry in indexer.iter_all()}
+
+    assert "." in entries
+    assert "season1" in entries
+    assert "season1/episode1.mp4" in entries
+    assert "season1/episode2.mp4" in entries
+    assert "orphan.txt" in entries
+    # ensure deleted entries disappear
+    (tmp_path / "orphan.txt").unlink()
+
+    with DirectoryIndexer(tmp_path, index_path) as indexer:
+        indexer.build_index(max_workers=2, batch_size=4)
+        entries_after_delete = {entry.path for entry in indexer.iter_all()}
+
+    assert "orphan.txt" not in entries_after_delete
+
+
+def test_directory_tags_generated_from_names(tmp_path: Path) -> None:
+    create_file(tmp_path / "Beach 2020" / "photo1.jpg")
+    create_file(tmp_path / "Beach 2021" / "photo2.jpg")
+    create_file(tmp_path / "Mountain Trip" / "photo3.jpg")
+    create_file(tmp_path / "Beach Sunset" / "photo4.jpg")
+
+    index_path = tmp_path / "index.db"
+    with DirectoryIndexer(tmp_path, index_path) as indexer:
+        indexer.build_index(max_workers=2, batch_size=4, min_tag_frequency=2)
+        tags = indexer.list_tags()
+        tag_counts = {tag.name: tag.match_count for tag in tags}
+
+        assert "beach" in tag_counts
+        assert tag_counts["beach"] == 3
+        assert "mountain" not in tag_counts
+
+        beach_directories = {entry.path for entry in indexer.list_directories_by_tag("beach")}
+
+    assert beach_directories == {
+        "Beach 2020",
+        "Beach 2021",
+        "Beach Sunset",
+    }

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,21 @@
+from image_viewer.menu import MenuItem, build_default_menu
+
+
+def test_default_menu_labels_are_chinese() -> None:
+    top_level = build_default_menu()
+    labels = [item.label for item in top_level]
+    assert labels == ["文件", "编辑", "视图", "窗口", "帮助"]
+
+
+def test_menu_item_to_dict_structure() -> None:
+    item = MenuItem(label="打开目录…", command="open-directory", accelerator="Ctrl+O")
+    data = item.to_dict()
+    assert data == {
+        "label": "打开目录…",
+        "command": "open-directory",
+        "accelerator": "Ctrl+O",
+    }
+
+
+def test_separator_serialization() -> None:
+    assert MenuItem.separator().to_dict() == {"type": "separator"}


### PR DESCRIPTION
## Summary
- 新增 Electron 前端并将标题、按钮、空状态等界面文案全部翻译为中文
- 通过主进程提供目录保存、自动标签及 IPC 接口，前端支持离线缓存和标签筛选
- README 追加中文界面的启动方式与功能说明，并扩展忽略规则

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcacd02aa883318ae53dfbdcfc32fd