### PR TITLE
Add automatic tag filtering for media folders

### DIFF
--- a/renderer/image-loader.js
+++ b/renderer/image-loader.js
@@ -1,0 +1,61 @@
+const activeTasks = new Map();
+
+self.addEventListener('message', async (event) => {
+  const data = event.data || {};
+  const { id, url, type } = data;
+
+  if (!id) {
+    return;
+  }
+
+  if (type === 'cancel') {
+    cancelTask(id);
+    return;
+  }
+
+  if (!url) {
+    postMessage({ id, error: '缺少图片地址' });
+    return;
+  }
+
+  if (activeTasks.has(id)) {
+    cancelTask(id);
+  }
+
+  const controller = new AbortController();
+  activeTasks.set(id, controller);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`图片请求失败（${response.status}）`);
+    }
+
+    const blob = await response.blob();
+    activeTasks.delete(id);
+
+    if (typeof createImageBitmap === 'function') {
+      const bitmap = await createImageBitmap(blob);
+      postMessage({ id, bitmap }, [bitmap]);
+      return;
+    }
+
+    const buffer = await blob.arrayBuffer();
+    postMessage({ id, buffer, type: blob.type }, [buffer]);
+  } catch (error) {
+    activeTasks.delete(id);
+    if (error?.name === 'AbortError') {
+      postMessage({ id, aborted: true });
+    } else {
+      postMessage({ id, error: error?.message || '图片加载失败' });
+    }
+  }
+});
+
+function cancelTask(id) {
+  const controller = activeTasks.get(id);
+  if (controller) {
+    controller.abort();
+    activeTasks.delete(id);
+  }
+}

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1,29 +1,33 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Local Media Explorer</title>
+    <title>本地媒体浏览器</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <header class="app-header">
-      <h1>Local Media Explorer</h1>
-      <button id="select-root">Select Directory</button>
+      <h1>本地媒体浏览器</h1>
+      <button id="select-root">选择目录</button>
     </header>
     <section class="tag-bar">
-      <h2>Saved Directories</h2>
+      <h2>已保存的目录</h2>
       <ul id="tag-list" class="tag-list"></ul>
     </section>
     <main class="app-body">
       <aside class="directory-panel">
-        <h2>Folders</h2>
-        <p id="current-root" class="current-root">No directory selected</p>
+        <h2>文件夹</h2>
+        <p id="current-root" class="current-root">尚未选择目录</p>
+        <div class="filter-section">
+          <h3>标签筛选</h3>
+          <div id="filter-tag-list" class="filter-tag-list"></div>
+        </div>
         <ul id="directory-list" class="directory-list"></ul>
       </aside>
       <section class="media-panel">
         <div class="media-panel-header">
-          <h2 id="media-heading">Media</h2>
+          <h2 id="media-heading">媒体</h2>
           <span id="media-count" class="media-count"></span>
         </div>
         <div id="media-grid" class="media-grid"></div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -37,7 +37,9 @@
           <h2 id="media-heading">媒体</h2>
           <span id="media-count" class="media-count"></span>
         </div>
-        <div id="media-grid" class="media-grid"></div>
+        <div class="media-panel-content">
+          <div id="media-grid" class="media-grid"></div>
+        </div>
       </section>
     </main>
     <script src="renderer.js" type="module"></script>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -17,13 +17,20 @@
     </section>
     <main class="app-body">
       <aside class="directory-panel">
-        <h2>文件夹</h2>
-        <p id="current-root" class="current-root">尚未选择目录</p>
-        <div class="filter-section">
-          <h3>标签筛选</h3>
-          <div id="filter-tag-list" class="filter-tag-list"></div>
+        <div class="directory-panel-header">
+          <h2>文件夹</h2>
+          <p id="current-root" class="current-root">尚未选择目录</p>
         </div>
-        <ul id="directory-list" class="directory-list"></ul>
+        <div class="directory-columns">
+          <section class="tag-column">
+            <h3>标签筛选</h3>
+            <div id="filter-tag-list" class="filter-tag-list"></div>
+          </section>
+          <section class="folder-column">
+            <h3>子文件夹</h3>
+            <ul id="directory-list" class="directory-list"></ul>
+          </section>
+        </div>
       </aside>
       <section class="media-panel">
         <div class="media-panel-header">

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -348,6 +348,15 @@ function renderMedia() {
     }
     thumb.className = 'media-thumb';
 
+    if (file.type === 'video') {
+      const badge = document.createElement('span');
+      badge.className = 'media-badge media-badge-video';
+      badge.textContent = '🎬';
+      badge.title = '视频';
+      badge.setAttribute('aria-hidden', 'true');
+      card.appendChild(badge);
+    }
+
     const info = document.createElement('div');
     info.className = 'media-info';
 
@@ -357,10 +366,24 @@ function renderMedia() {
 
     const meta = document.createElement('span');
     meta.className = 'media-meta';
-    meta.textContent = file.type.toUpperCase();
+    if (file.type === 'video') {
+      meta.textContent = '视频';
+    } else if (file.type === 'image') {
+      meta.textContent = '图片';
+    } else {
+      meta.textContent = String(file.type ?? '').toUpperCase() || '媒体';
+    }
 
     info.appendChild(name);
     info.appendChild(meta);
+
+    const ratingValue = file.rating ?? file.score;
+    if (ratingValue !== undefined && ratingValue !== null && ratingValue !== '') {
+      const rating = document.createElement('span');
+      rating.className = 'media-rating';
+      rating.textContent = `评分：${ratingValue}`;
+      info.appendChild(rating);
+    }
 
     card.appendChild(thumb);
     card.appendChild(info);
@@ -373,18 +396,33 @@ function extractKeywords(name) {
   if (!name) {
     return [];
   }
-  const pattern = /[\p{Script=Han}\p{L}\p{N}]+/gu;
+
+  const pattern = /(?:[⭐]+|[\p{Script=Han}\p{L}\p{N}]+)/gu;
   const matches = name.match(pattern) || [];
-  return Array.from(
-    new Set(
-      matches
-        .map((token) => token.trim().toLowerCase())
-        .filter((token) => token.length > 1)
-    )
-  );
+
+  const normalized = matches
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .map((token) => {
+      if (/^⭐+$/u.test(token)) {
+        return token;
+      }
+      return token.toLowerCase();
+    })
+    .filter((token) => {
+      if (/^⭐+$/u.test(token)) {
+        return true;
+      }
+      return token.length > 1;
+    });
+
+  return Array.from(new Set(normalized));
 }
 
 function humanizeKeyword(keyword) {
+  if (/^⭐+$/u.test(keyword)) {
+    return keyword;
+  }
   if (/^[\p{Script=Han}]+$/u.test(keyword)) {
     return keyword;
   }

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -122,15 +122,21 @@ body {
 }
 
 .directory-panel {
-  width: 260px;
+  width: 420px;
   border-right: 1px solid var(--border-color);
   background: var(--panel-bg);
   padding: 1rem;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.directory-panel h2 {
-  margin: 0 0 0.5rem;
+.directory-panel-header {
+  margin-bottom: 1rem;
+}
+
+.directory-panel-header h2 {
+  margin: 0 0 0.35rem;
   font-size: 1rem;
 }
 
@@ -138,14 +144,26 @@ body {
   font-size: 0.8rem;
   color: #57606a;
   word-break: break-all;
-  margin-bottom: 0.75rem;
+  margin: 0;
 }
 
-.filter-section {
-  margin-bottom: 1rem;
+.directory-columns {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1rem;
+  overflow: hidden;
 }
 
-.filter-section h3 {
+.tag-column,
+.folder-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tag-column h3,
+.folder-column h3 {
   margin: 0 0 0.5rem;
   font-size: 0.9rem;
   color: #57606a;
@@ -155,7 +173,8 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .filter-tag-button {
@@ -191,6 +210,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .directory-item {
@@ -224,6 +245,20 @@ body {
   flex-direction: column;
   padding: 1rem 1.5rem;
   overflow: hidden;
+}
+
+@media (max-width: 960px) {
+  .directory-panel {
+    width: 100%;
+  }
+
+  .directory-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .tag-column {
+    margin-bottom: 1rem;
+  }
 }
 
 .media-panel-header {

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -9,13 +9,20 @@
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   background: var(--bg-color);
   color: var(--text-color);
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .app-header {
@@ -26,6 +33,7 @@ body {
   border-bottom: 1px solid var(--border-color);
   background: var(--panel-bg);
   backdrop-filter: blur(6px);
+  flex-shrink: 0;
 }
 
 .app-header h1 {
@@ -56,6 +64,7 @@ body {
   border-bottom: 1px solid var(--border-color);
   background: var(--panel-bg);
   overflow-x: auto;
+  flex-shrink: 0;
 }
 
 .tag-bar h2 {

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -311,11 +311,33 @@ body {
   flex-direction: column;
   box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+  position: relative;
 }
 
 .media-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 12px rgba(15, 23, 42, 0.15);
+}
+
+.media-badge {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.75);
+  color: #ffffff;
+  font-size: 0.95rem;
+  z-index: 2;
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.3);
+}
+
+.media-badge-video {
+  font-size: 0.9rem;
 }
 
 .media-thumb {
@@ -344,6 +366,11 @@ body {
 .media-meta {
   font-size: 0.75rem;
   color: #57606a;
+}
+
+.media-rating {
+  font-size: 0.75rem;
+  color: #7f56d9;
 }
 
 .empty-state {

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -347,6 +347,28 @@ body {
   background: #f0f3f6;
 }
 
+canvas.media-thumb {
+  display: block;
+  height: auto;
+}
+
+canvas.media-thumb[data-loading] {
+  position: relative;
+  background: linear-gradient(90deg, #f0f3f6 0%, #e3e8ef 50%, #f0f3f6 100%);
+  background-size: 200% 100%;
+  animation: media-thumb-loading 1.2s ease-in-out infinite;
+}
+
+canvas.media-thumb[data-error] {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(239, 68, 68, 0.1),
+    rgba(239, 68, 68, 0.1) 10px,
+    rgba(239, 68, 68, 0.2) 10px,
+    rgba(239, 68, 68, 0.2) 20px
+  );
+}
+
 .media-card video.media-thumb {
   background: #0f172a;
 }
@@ -371,6 +393,15 @@ body {
 .media-rating {
   font-size: 0.75rem;
   color: #7f56d9;
+}
+
+@keyframes media-thumb-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .empty-state {

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -118,6 +118,7 @@ body {
 .app-body {
   display: flex;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -128,6 +129,7 @@ body {
   padding: 1rem;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -152,6 +154,7 @@ body {
   display: grid;
   grid-template-columns: 200px 1fr;
   gap: 1rem;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -159,7 +162,9 @@ body {
 .folder-column {
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
   min-height: 0;
+  overflow: hidden;
 }
 
 .tag-column h3,
@@ -173,6 +178,8 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  flex: 1;
+  align-content: flex-start;
   overflow-y: auto;
   padding-right: 0.25rem;
 }
@@ -210,6 +217,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  flex: 1;
   overflow-y: auto;
   padding-right: 0.25rem;
 }
@@ -244,6 +252,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: 1rem 1.5rem;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -272,6 +281,7 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 1rem;
+  flex: 1;
   overflow-y: auto;
   padding-bottom: 1rem;
 }

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -141,6 +141,49 @@ body {
   margin-bottom: 0.75rem;
 }
 
+.filter-section {
+  margin-bottom: 1rem;
+}
+
+.filter-section h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  color: #57606a;
+}
+
+.filter-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-tag-button {
+  border: 1px solid var(--border-color);
+  background: #f0f6ff;
+  color: var(--accent-color);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.filter-tag-button:hover {
+  background: rgba(9, 105, 218, 0.16);
+}
+
+.filter-tag-button.active {
+  background: var(--accent-color);
+  color: var(--accent-color-contrast);
+  border-color: var(--accent-color);
+}
+
+.filter-tag-empty {
+  font-size: 0.8rem;
+  color: #8c959f;
+}
+
 .directory-list {
   list-style: none;
   padding: 0;

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -265,6 +265,13 @@ body {
   overflow: hidden;
 }
 
+.media-panel-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
 @media (max-width: 960px) {
   .directory-panel {
     width: 100%;
@@ -291,7 +298,7 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 1rem;
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
   padding-bottom: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- add a tag filter section in the sidebar so repeated keywords in folder names become selectable tags
- derive tag metadata when scanning a root and filter the directory list and current selection by the active tag
- preserve saved directory shortcuts while clearing filters when switching between roots

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dcca00a4f08331be6cacf2044de30f