### PR TITLE
Add paginated media loading for media directories

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
-const { collectLeafDirectories } = require('./directoryScanner');
+const { collectLeafDirectories, listMediaFiles } = require('./directoryScanner');
 const {
   initPreferences,
   getRootTags,
@@ -75,6 +75,33 @@ ipcMain.handle('scan-directory', async (_event, rootPath) => {
 
   const leaves = await collectLeafDirectories(rootPath);
   return leaves;
+});
+
+ipcMain.handle('list-media-files', async (_event, directoryPath, options = {}) => {
+  if (!directoryPath) {
+    return {
+      files: [],
+      total: 0,
+      offset: 0,
+      nextOffset: 0,
+      hasMore: false,
+      error: 'Missing directory path',
+    };
+  }
+
+  try {
+    return await listMediaFiles(directoryPath, options);
+  } catch (error) {
+    console.error('Failed to list media files', error);
+    return {
+      files: [],
+      total: 0,
+      offset: 0,
+      nextOffset: 0,
+      hasMore: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 });
 
 ipcMain.handle('get-root-tags', async () => {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,6 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('mediaApi', {
   selectRoot: () => ipcRenderer.invoke('select-root'),
   scanDirectory: (rootPath) => ipcRenderer.invoke('scan-directory', rootPath),
+  listMediaFiles: (directoryPath, options) =>
+    ipcRenderer.invoke('list-media-files', directoryPath, options),
   openFile: (filePath) => ipcRenderer.invoke('open-file', filePath),
   openDirectory: (directoryPath) => ipcRenderer.invoke('open-directory', directoryPath),
   getRootTags: () => ipcRenderer.invoke('get-root-tags'),


### PR DESCRIPTION
## Summary
- update the directory scanner to report leaf metadata only and add a paginated `listMediaFiles` helper
- expose a `list-media-files` IPC handler and preload bridge so the renderer can request batches on demand
- refactor the renderer to cache only directory summaries, stream media batches per selection, and show loading/error states

## Testing
- node -e "(async () => { const scanner = require('./src/main/directoryScanner'); const result = await scanner.listMediaFiles('.', { limit: 3 }); console.log(result.total, result.files.length, result.hasMore); })();"

------
https://chatgpt.com/codex/tasks/task_e_68e2742031ac8331ab1bde225dee978f