### PR TITLE
Add interactive media viewer overlay

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -66,6 +66,82 @@
         </div>
       </section>
     </main>
+    <div id="media-viewer" class="media-viewer" hidden aria-hidden="true">
+      <div id="media-viewer-backdrop" class="media-viewer__backdrop"></div>
+      <div
+        class="media-viewer__dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="media-viewer-filename"
+      >
+        <header class="media-viewer__header">
+          <button
+            id="media-viewer-close"
+            type="button"
+            class="media-viewer__icon-button"
+            aria-label="关闭预览"
+          >
+            ×
+          </button>
+        </header>
+        <div class="media-viewer__content">
+          <button
+            id="media-viewer-prev"
+            type="button"
+            class="media-viewer__nav media-viewer__nav--prev"
+            aria-label="上一项"
+          >
+            ‹
+          </button>
+          <div id="media-viewer-stage" class="media-viewer__stage">
+            <div
+              id="media-viewer-loading"
+              class="media-viewer__loading"
+              hidden
+              aria-live="polite"
+            >
+              正在加载…
+            </div>
+            <img
+              id="media-viewer-image"
+              class="media-viewer__image"
+              alt=""
+              hidden
+            />
+            <video
+              id="media-viewer-video"
+              class="media-viewer__video"
+              controls
+              playsinline
+              hidden
+            ></video>
+          </div>
+          <button
+            id="media-viewer-next"
+            type="button"
+            class="media-viewer__nav media-viewer__nav--next"
+            aria-label="下一项"
+          >
+            ›
+          </button>
+        </div>
+        <footer class="media-viewer__footer">
+          <div class="media-viewer__caption">
+            <span id="media-viewer-filename" class="media-viewer__filename"></span>
+            <span id="media-viewer-counter" class="media-viewer__counter"></span>
+          </div>
+          <div class="media-viewer__actions">
+            <button
+              id="media-viewer-open-external"
+              type="button"
+              class="media-viewer__button"
+            >
+              在系统中打开
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
     <script src="renderer.js" type="module"></script>
   </body>
 </html>

--- a/renderer/media-viewer.js
+++ b/renderer/media-viewer.js
@@ -1,0 +1,473 @@
+const KEY_ESCAPE = 'Escape';
+const KEY_PREV = 'ArrowLeft';
+const KEY_NEXT = 'ArrowRight';
+
+export function createMediaViewer({
+  elements = {},
+  mediaApi,
+  getSession,
+  getSessionTotal,
+  setPendingIndex,
+  fetchMore,
+} = {}) {
+  const {
+    container,
+    backdrop,
+    closeButton,
+    prevButton,
+    nextButton,
+    imageEl,
+    videoEl,
+    loadingEl,
+    filenameEl,
+    counterEl,
+    openExternalButton,
+  } = elements;
+
+  const state = {
+    isOpen: false,
+    index: -1,
+    sessionRequestId: 0,
+    currentFile: null,
+  };
+
+  if (openExternalButton) {
+    openExternalButton.disabled = true;
+  }
+
+  if (closeButton) {
+    closeButton.addEventListener('click', () => close());
+  }
+
+  if (backdrop) {
+    backdrop.addEventListener('click', () => close());
+  }
+
+  if (prevButton) {
+    prevButton.addEventListener('click', () => step(-1));
+  }
+
+  if (nextButton) {
+    nextButton.addEventListener('click', () => step(1));
+  }
+
+  if (openExternalButton) {
+    openExternalButton.addEventListener('click', () => {
+      if (openExternalButton.disabled) {
+        return;
+      }
+      const path = state.currentFile?.path;
+      if (path) {
+        void mediaApi?.openFile?.(path);
+      }
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('keydown', handleKeydown);
+  }
+
+  return {
+    openAtIndex,
+    handleItemsAppended,
+    reset,
+    close,
+    handleKeydown,
+  };
+
+  function openAtIndex(index) {
+    if (typeof index !== 'number' || Number.isNaN(index)) {
+      return;
+    }
+
+    const session = getSession?.();
+    if (!session) {
+      return;
+    }
+
+    const total = normalizeTotal(session);
+    if (!total) {
+      return;
+    }
+
+    const clampedIndex = Math.max(0, Math.min(index, total - 1));
+
+    if (!container) {
+      const file = session.items?.[clampedIndex];
+      if (file?.path) {
+        void mediaApi?.openFile?.(file.path);
+      }
+      return;
+    }
+
+    ensureActive(session.requestId);
+
+    if (!Array.isArray(session.items) || clampedIndex >= session.items.length) {
+      setPendingIndex?.(clampedIndex);
+      showLoadingState(clampedIndex, total);
+      void fetchMore?.(session);
+      return;
+    }
+
+    setPendingIndex?.(null);
+    showItem(clampedIndex);
+  }
+
+  function handleItemsAppended(session) {
+    if (!session || session !== getSession?.()) {
+      return;
+    }
+
+    const total = normalizeTotal(session);
+
+    if (
+      session.pendingIndex != null &&
+      session.pendingIndex >= 0 &&
+      session.pendingIndex < (session.items?.length ?? 0) &&
+      state.isOpen &&
+      state.sessionRequestId === session.requestId
+    ) {
+      showItem(session.pendingIndex);
+      return;
+    }
+
+    if (!state.isOpen) {
+      return;
+    }
+
+    updateNavigation(total);
+  }
+
+  function reset() {
+    close(true);
+  }
+
+  function close(force = false) {
+    if (!container) {
+      if (!state.isOpen && !force) {
+        return;
+      }
+      setPendingIndex?.(null);
+      state.isOpen = false;
+      state.index = -1;
+      state.currentFile = null;
+      state.sessionRequestId = 0;
+      return;
+    }
+
+    setPendingIndex?.(null);
+
+    if (!state.isOpen && !force) {
+      return;
+    }
+
+    stopVideo();
+
+    if (imageEl) {
+      imageEl.src = '';
+      imageEl.hidden = true;
+      imageEl.alt = '';
+    }
+
+    if (videoEl) {
+      videoEl.hidden = true;
+      videoEl.removeAttribute('src');
+    }
+
+    if (loadingEl) {
+      loadingEl.hidden = true;
+    }
+
+    if (filenameEl) {
+      filenameEl.textContent = '';
+    }
+
+    if (counterEl) {
+      counterEl.textContent = '';
+    }
+
+    if (openExternalButton) {
+      openExternalButton.disabled = true;
+    }
+
+    delete container.dataset.active;
+    container.setAttribute('aria-hidden', 'true');
+    container.hidden = true;
+
+    if (document?.body) {
+      delete document.body.dataset.mediaViewerOpen;
+    }
+
+    state.isOpen = false;
+    state.index = -1;
+    state.currentFile = null;
+    state.sessionRequestId = 0;
+
+    updateNavigation(0);
+  }
+
+  function handleKeydown(event) {
+    if (!state.isOpen) {
+      return;
+    }
+
+    if (event.key === KEY_ESCAPE) {
+      event.preventDefault();
+      close();
+      return;
+    }
+
+    if (event.key === KEY_PREV) {
+      event.preventDefault();
+      step(-1);
+      return;
+    }
+
+    if (event.key === KEY_NEXT) {
+      event.preventDefault();
+      step(1);
+    }
+  }
+
+  function ensureActive(sessionRequestId) {
+    if (!container) {
+      return;
+    }
+
+    if (container.hidden) {
+      container.hidden = false;
+    }
+
+    container.dataset.active = 'true';
+    container.setAttribute('aria-hidden', 'false');
+
+    if (document?.body) {
+      document.body.dataset.mediaViewerOpen = 'true';
+    }
+
+    state.isOpen = true;
+    state.sessionRequestId = sessionRequestId;
+  }
+
+  function showLoadingState(index, total) {
+    ensureActive(state.sessionRequestId);
+    stopVideo();
+
+    if (imageEl) {
+      imageEl.src = '';
+      imageEl.hidden = true;
+      imageEl.alt = '';
+    }
+
+    if (videoEl) {
+      videoEl.hidden = true;
+      videoEl.removeAttribute('src');
+    }
+
+    if (loadingEl) {
+      loadingEl.hidden = false;
+    }
+
+    if (filenameEl) {
+      filenameEl.textContent = '正在加载…';
+    }
+
+    if (counterEl) {
+      if (typeof total === 'number' && total > 0) {
+        const safeIndex = Math.min(index, total - 1);
+        counterEl.textContent = `${safeIndex + 1} / ${total}`;
+      } else {
+        counterEl.textContent = '';
+      }
+    }
+
+    if (openExternalButton) {
+      openExternalButton.disabled = true;
+    }
+
+    state.index = index;
+    state.currentFile = null;
+
+    updateNavigation(total);
+  }
+
+  function showItem(index) {
+    const session = getSession?.();
+    if (!session || session.requestId === 0) {
+      return;
+    }
+
+    const total = normalizeTotal(session);
+    if (!total) {
+      return;
+    }
+
+    const targetIndex = Math.max(0, Math.min(index, total - 1));
+
+    if (!Array.isArray(session.items) || targetIndex >= session.items.length) {
+      setPendingIndex?.(targetIndex);
+      showLoadingState(targetIndex, total);
+      void fetchMore?.(session);
+      return;
+    }
+
+    const file = session.items[targetIndex];
+    if (!file) {
+      return;
+    }
+
+    ensureActive(session.requestId);
+    setPendingIndex?.(null);
+
+    if (loadingEl) {
+      loadingEl.hidden = true;
+    }
+
+    stopVideo();
+
+    const resolvedUrl =
+      file.fileUrl || (file.path ? `file://${encodeURI(file.path)}` : '');
+
+    if (file.type === 'video') {
+      if (videoEl) {
+        if (resolvedUrl) {
+          videoEl.src = resolvedUrl;
+        } else {
+          videoEl.removeAttribute('src');
+        }
+        videoEl.hidden = false;
+        videoEl.load?.();
+      }
+      if (imageEl) {
+        imageEl.src = '';
+        imageEl.hidden = true;
+      }
+    } else {
+      if (imageEl) {
+        if (resolvedUrl) {
+          imageEl.src = resolvedUrl;
+        } else {
+          imageEl.removeAttribute('src');
+        }
+        imageEl.alt = file?.name || file?.path || '';
+        imageEl.hidden = false;
+      }
+      if (videoEl) {
+        videoEl.hidden = true;
+        videoEl.removeAttribute('src');
+      }
+    }
+
+    if (filenameEl) {
+      filenameEl.textContent = file?.name || file?.path || '';
+    }
+
+    if (counterEl) {
+      counterEl.textContent = `${targetIndex + 1} / ${total}`;
+    }
+
+    if (openExternalButton) {
+      openExternalButton.disabled = !file?.path;
+    }
+
+    state.index = targetIndex;
+    state.currentFile = file;
+    state.sessionRequestId = session.requestId;
+
+    updateNavigation(total);
+
+    if (
+      Array.isArray(session.items) &&
+      targetIndex >= session.items.length - 2 &&
+      session.items.length < total
+    ) {
+      void fetchMore?.(session);
+    }
+  }
+
+  function step(delta) {
+    if (!state.isOpen || typeof delta !== 'number' || !delta) {
+      return;
+    }
+
+    const session = getSession?.();
+    if (!session) {
+      return;
+    }
+
+    const total = normalizeTotal(session);
+    if (!total) {
+      return;
+    }
+
+    const pendingIndex = session.pendingIndex;
+    const currentIndex =
+      pendingIndex != null ? pendingIndex : state.index;
+
+    if (currentIndex < 0) {
+      return;
+    }
+
+    const nextIndex = Math.max(0, Math.min(currentIndex + delta, total - 1));
+    if (nextIndex === currentIndex) {
+      return;
+    }
+
+    openAtIndex(nextIndex);
+  }
+
+  function updateNavigation(totalOverride) {
+    if (!prevButton && !nextButton) {
+      return;
+    }
+
+    const session = getSession?.();
+    const pendingIndex = session?.pendingIndex;
+    const activeIndex =
+      pendingIndex != null ? pendingIndex : state.index;
+
+    const total =
+      typeof totalOverride === 'number' && totalOverride >= 0
+        ? totalOverride
+        : normalizeTotal(session);
+
+    if (prevButton) {
+      prevButton.disabled = !state.isOpen || total <= 0 || activeIndex <= 0;
+    }
+
+    if (nextButton) {
+      nextButton.disabled =
+        !state.isOpen || total <= 0 || activeIndex >= total - 1;
+    }
+  }
+
+  function stopVideo() {
+    if (!videoEl) {
+      return;
+    }
+
+    try {
+      videoEl.pause();
+    } catch (error) {
+      // Ignore pause errors so closing flow continues.
+    }
+    videoEl.removeAttribute('src');
+    videoEl.load?.();
+  }
+
+  function normalizeTotal(session) {
+    if (typeof getSessionTotal === 'function') {
+      return getSessionTotal(session) || 0;
+    }
+
+    if (!session) {
+      return 0;
+    }
+
+    if (typeof session.totalCount === 'number' && session.totalCount > 0) {
+      return session.totalCount;
+    }
+
+    return Array.isArray(session.items) ? session.items.length : 0;
+  }
+}

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -653,6 +653,7 @@ body {
   box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   position: relative;
+  cursor: pointer;
 }
 
 .media-card:hover {
@@ -748,4 +749,288 @@ canvas.media-thumb[data-error] {
 .empty-state {
   color: #57606a;
   font-size: 0.9rem;
+}
+
+body[data-media-viewer-open='true'] {
+  overflow: hidden;
+}
+
+#media-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+#media-viewer[hidden] {
+  display: none;
+}
+
+#media-viewer[data-active='true'] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.media-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(12px);
+}
+
+.media-viewer__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  max-height: calc(100vh - 4rem);
+  background: var(--panel-bg);
+  color: var(--text-color);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.media-viewer__header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.75rem 0.75rem 0;
+}
+
+.media-viewer__icon-button {
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.media-viewer__icon-button:hover {
+  background: rgba(15, 23, 42, 0.16);
+  transform: scale(1.05);
+}
+
+.media-viewer__icon-button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.media-viewer__content {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.media-viewer__stage {
+  position: relative;
+  width: 100%;
+  max-height: calc(100vh - 12rem);
+  min-height: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.media-viewer__image,
+.media-viewer__video {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.media-viewer__video {
+  background: #000000;
+}
+
+.media-viewer__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.8);
+  color: #ffffff;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.media-viewer__loading[hidden] {
+  display: none;
+}
+
+.media-viewer__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  border: none;
+  background: rgba(15, 23, 42, 0.35);
+  color: #ffffff;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1.5rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.media-viewer__nav:hover {
+  background: rgba(15, 23, 42, 0.55);
+  transform: translateY(-50%) scale(1.05);
+}
+
+.media-viewer__nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.media-viewer__nav:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.media-viewer__nav--prev {
+  left: 1.25rem;
+}
+
+.media-viewer__nav--next {
+  right: 1.25rem;
+}
+
+.media-viewer__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  background: rgba(248, 250, 252, 0.75);
+}
+
+.media-viewer__caption {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.media-viewer__filename {
+  font-weight: 600;
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.media-viewer__counter {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.media-viewer__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.media-viewer__button {
+  border: none;
+  background: var(--accent-color);
+  color: var(--accent-color-contrast);
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+.media-viewer__button:hover {
+  filter: brightness(1.05);
+}
+
+.media-viewer__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  filter: none;
+}
+
+@media (max-width: 900px) {
+  #media-viewer {
+    padding: 1.5rem;
+  }
+
+  .media-viewer__dialog {
+    width: 100%;
+    max-height: calc(100vh - 3rem);
+  }
+
+  .media-viewer__content {
+    padding: 0.5rem 1rem;
+  }
+
+  .media-viewer__stage {
+    min-height: 260px;
+  }
+
+  .media-viewer__nav {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1.35rem;
+  }
+
+  .media-viewer__nav--prev {
+    left: 0.75rem;
+  }
+
+  .media-viewer__nav--next {
+    right: 0.75rem;
+  }
+}
+
+@media (max-width: 600px) {
+  #media-viewer {
+    padding: 1rem;
+  }
+
+  .media-viewer__dialog {
+    border-radius: 12px;
+  }
+
+  .media-viewer__stage {
+    min-height: 220px;
+  }
+
+  .media-viewer__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- add a hidden media viewer overlay with navigation, loading state, and external open button
- style the overlay for full-screen presentation and lock body scrolling when active
- enhance renderer logic to manage a media session, open items in the overlay, and handle navigation and keyboard controls

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e278bdf1c883318a26319c37c70689