### PR TITLE
Add i18n support (en / zh-CN) and convert UI strings to use translations

### DIFF
--- a/renderer/i18n.js
+++ b/renderer/i18n.js
@@ -1,0 +1,122 @@
+(function initializeI18n(globalScope) {
+  const translations = {
+    en: {
+      appTitle: 'Local Media Browser',
+      selectDirectory: 'Select directory',
+      selectDirectoryUnavailable: 'Select directory (unavailable)',
+      savedDirectories: 'Saved directories',
+      folders: 'Folders',
+      noDirectorySelected: 'No directory selected',
+      tagFilters: 'Tag filters',
+      subfolders: 'Subfolders',
+      media: 'Media',
+      openInExplorer: 'Open in File Explorer',
+      closePreview: 'Close preview',
+      previousImage: 'Previous image',
+      nextImage: 'Next image',
+      openInPhotos: 'Open in system photos app',
+      demoNotice: 'Demo mode only displays virtual directory metadata and does not read or write media files.',
+      noSavedDirectories: 'No directories have been saved yet.',
+      savedDirectoriesUnavailable: 'Saved directories are unavailable.',
+      removeItem: 'Remove {label}',
+      tagsAfterSelection: 'Tags will be generated automatically after you select a directory.',
+      noGeneratedTags: 'No repeated keywords were found, so there are no generated tags yet.',
+      all: 'All',
+      noMatchingTags: 'No matching tags found.',
+      excludeTag: 'Exclude tag {label}',
+      excludeTagTitle: 'Exclude this tag from the tag list',
+      tagExclusions: 'Tag exclusions',
+      collapse: 'Collapse',
+      expand: 'Expand',
+      collapseTagExclusions: 'Collapse tag exclusion settings',
+      expandTagExclusions: 'Expand tag exclusion settings',
+      excludedTagsHelp: 'Excluded tags are hidden from the filter list and are not used to group subfolders.',
+      excludedTagInput: 'Enter a tag to exclude',
+      add: 'Add',
+      noExcludedTags: 'No tags have been excluded.',
+      restore: 'Restore',
+      noFoldersForTag: 'No folders match the “{label}” tag.',
+      noFoldersForSelection: 'No folders match the selected tag.',
+      noMediaInSelection: 'The selected directory contains no media files.',
+      selectDirectoryToStart: 'Select a directory to get started.',
+      folderContextHint: 'Right-click to open this directory in the system file manager',
+      openNamedDirectory: 'Open {path} in File Explorer',
+      directoryOpenFailed: 'Unable to open the directory',
+      directoryOpenAlert: 'Unable to open this directory in the system file manager. Make sure the path exists.',
+      directoryPathCopied: 'Directory path copied:\n{path}',
+      copyDirectoryPath: 'Copy the directory path:',
+      savedDirectory: 'Saved directory',
+      loadingSavedDirectory: 'Loading saved directory…',
+      removeSavedDirectoryConfirm: 'Remove the saved directory “{label}”?',
+      itemCount: '{count} items',
+      noMediaInFolder: 'This folder contains no media files.',
+      mediaUnavailable: 'Media files cannot be loaded in this version.',
+      mediaLoadFailed: 'Unable to load media files.',
+      searchTags: 'Search tags',
+      confirm: 'Confirm',
+      tagSort: 'Tag sorting',
+      sortAlphabetically: 'Alphabetical',
+      sortByCount: 'By count',
+      loading: 'Loading…',
+      loadingProgress: 'Loading {loaded} / {total}',
+      loadingComplete: 'Loading complete',
+      loadingFailed: 'Loading failed',
+      video: 'Video',
+      image: 'Image',
+      rating: 'Rating: {rating}',
+      unknownImageResult: 'Unknown image loading result',
+      missingImageUrl: 'Missing image URL',
+      imageLoadFailed: 'Image failed to load',
+    },
+    'zh-CN': {
+      appTitle: '本地媒体浏览器', selectDirectory: '选择目录', selectDirectoryUnavailable: '选择目录（不可用）',
+      savedDirectories: '已保存的目录', folders: '文件夹', noDirectorySelected: '尚未选择目录', tagFilters: '标签筛选',
+      subfolders: '子文件夹', media: '媒体', openInExplorer: '在资源管理器中打开', closePreview: '关闭预览',
+      previousImage: '上一张', nextImage: '下一张', openInPhotos: '在系统照片中打开',
+      demoNotice: '演示模式仅展示虚拟目录元数据，不会读取或写入媒体文件。', noSavedDirectories: '尚未保存任何目录。',
+      savedDirectoriesUnavailable: '无法获取已保存的目录。', removeItem: '移除 {label}',
+      tagsAfterSelection: '选择目录后会自动生成标签。', noGeneratedTags: '未发现重复关键词，暂无生成标签。', all: '全部',
+      noMatchingTags: '没有找到匹配的标签。', excludeTag: '排除标签 {label}', excludeTagTitle: '从标签列表中排除此标签',
+      tagExclusions: '标签排除', collapse: '收起', expand: '展开', collapseTagExclusions: '收起标签排除设置',
+      expandTagExclusions: '展开标签排除设置', excludedTagsHelp: '被排除的标签不会在筛选列表中显示，子文件夹也不会按照这些标签分组。',
+      excludedTagInput: '输入要排除的标签', add: '添加', noExcludedTags: '尚未排除任何标签。', restore: '恢复',
+      noFoldersForTag: '没有找到与标签“{label}”匹配的文件夹。', noFoldersForSelection: '没有找到匹配所选标签的文件夹。',
+      noMediaInSelection: '所选目录中没有媒体文件。', selectDirectoryToStart: '请选择一个目录开始。',
+      folderContextHint: '右键可在系统文件管理器中打开该目录', openNamedDirectory: '在资源管理器中打开 {path}',
+      directoryOpenFailed: '无法打开目录', directoryOpenAlert: '无法在系统文件管理器中打开该目录，请确认路径是否存在。',
+      directoryPathCopied: '已复制目录路径：\n{path}', copyDirectoryPath: '请复制目录路径：', savedDirectory: '已保存的目录',
+      loadingSavedDirectory: '正在加载已保存的目录…', removeSavedDirectoryConfirm: '要移除已保存的目录“{label}”吗？',
+      itemCount: '{count} 个项目', noMediaInFolder: '该文件夹中没有媒体文件。', mediaUnavailable: '当前版本无法加载媒体文件。',
+      mediaLoadFailed: '无法加载媒体文件。', searchTags: '搜索标签', confirm: '确认', tagSort: '标签排序',
+      sortAlphabetically: '按首字母', sortByCount: '按数量', loading: '正在加载…', loadingProgress: '加载中 {loaded} / {total}',
+      loadingComplete: '加载完成', loadingFailed: '加载失败', video: '视频', image: '图片', rating: '评分：{rating}',
+      unknownImageResult: '未知的图片加载结果', missingImageUrl: '缺少图片地址', imageLoadFailed: '图片加载失败',
+    },
+  };
+
+  let currentLocale = 'en';
+
+  function setLocale(locale) {
+    currentLocale = Object.prototype.hasOwnProperty.call(translations, locale) ? locale : 'en';
+    if (globalScope.document?.documentElement) globalScope.document.documentElement.lang = currentLocale;
+    return currentLocale;
+  }
+
+  function t(key, values = {}) {
+    const template = translations[currentLocale][key] ?? translations.en[key] ?? key;
+    return template.replace(/\{(\w+)\}/gu, (_match, name) => String(values[name] ?? `{${name}}`));
+  }
+
+  function translateDocument(root = globalScope.document) {
+    if (!root) return;
+    root.querySelectorAll('[data-i18n]').forEach((node) => { node.textContent = t(node.dataset.i18n); });
+    root.querySelectorAll('[data-i18n-aria-label]').forEach((node) => {
+      node.setAttribute('aria-label', t(node.dataset.i18nAriaLabel));
+    });
+    if (root.documentElement) root.documentElement.lang = currentLocale;
+  }
+
+  const api = { t, setLocale, translateDocument, translations, getLocale: () => currentLocale };
+  globalScope.ImageViewerI18n = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/renderer/image-loader.js
+++ b/renderer/image-loader.js
@@ -14,7 +14,7 @@ self.addEventListener('message', async (event) => {
   }
 
   if (!url) {
-    postMessage({ id, error: '缺少图片地址' });
+    postMessage({ id, error: 'Missing image URL' });
     return;
   }
 
@@ -28,7 +28,7 @@ self.addEventListener('message', async (event) => {
   try {
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
-      throw new Error(`图片请求失败（${response.status}）`);
+      throw new Error(`Image request failed (${response.status})`);
     }
 
     const blob = await response.blob();
@@ -47,7 +47,7 @@ self.addEventListener('message', async (event) => {
     if (error?.name === 'AbortError') {
       postMessage({ id, aborted: true });
     } else {
-      postMessage({ id, error: error?.message || '图片加载失败' });
+      postMessage({ id, error: error?.message || 'Image failed to load' });
     }
   }
 });

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1,34 +1,34 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>本地媒体浏览器</title>
+    <title data-i18n="appTitle">Local Media Browser</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <header class="app-header">
-      <h1>本地媒体浏览器</h1>
-      <button id="select-root">选择目录</button>
+      <h1 data-i18n="appTitle">Local Media Browser</h1>
+      <button id="select-root" data-i18n="selectDirectory">Select directory</button>
     </header>
     <p id="app-message" class="app-message" role="status" hidden></p>
     <section class="tag-bar">
-      <h2>已保存的目录</h2>
+      <h2 data-i18n="savedDirectories">Saved directories</h2>
       <ul id="tag-list" class="tag-list"></ul>
     </section>
     <main class="app-body">
       <aside class="directory-panel">
         <div class="directory-panel-header">
-          <h2>文件夹</h2>
-          <p id="current-root" class="current-root">尚未选择目录</p>
+          <h2 data-i18n="folders">Folders</h2>
+          <p id="current-root" class="current-root" data-i18n="noDirectorySelected">No directory selected</p>
         </div>
         <div class="directory-columns">
           <section class="tag-column">
-            <h3>标签筛选</h3>
+            <h3 data-i18n="tagFilters">Tag filters</h3>
             <div id="filter-tag-list" class="filter-tag-list"></div>
           </section>
           <section class="folder-column">
-            <h3>子文件夹</h3>
+            <h3 data-i18n="subfolders">Subfolders</h3>
             <ul id="directory-list" class="directory-list"></ul>
           </section>
         </div>
@@ -36,7 +36,7 @@
       <section class="media-panel">
         <div class="media-panel-header">
           <div class="media-heading-group">
-            <h2 id="media-heading">媒体</h2>
+            <h2 id="media-heading" data-i18n="media">Media</h2>
             <span id="media-count" class="media-count"></span>
           </div>
           <button
@@ -45,7 +45,7 @@
             type="button"
             disabled
           >
-            在资源管理器中打开
+            <span data-i18n="openInExplorer">Open in File Explorer</span>
           </button>
         </div>
         <div class="media-panel-content">
@@ -79,7 +79,8 @@
         id="media-viewer-close"
         class="media-viewer-close"
         type="button"
-        aria-label="关闭预览"
+        aria-label="Close preview"
+        data-i18n-aria-label="closePreview"
       >
         ×
       </button>
@@ -88,7 +89,8 @@
           id="media-viewer-prev"
           class="media-viewer-nav media-viewer-prev"
           type="button"
-          aria-label="上一张"
+          aria-label="Previous image"
+          data-i18n-aria-label="previousImage"
           disabled
         >
           ‹
@@ -101,7 +103,8 @@
           id="media-viewer-next"
           class="media-viewer-nav media-viewer-next"
           type="button"
-          aria-label="下一张"
+          aria-label="Next image"
+          data-i18n-aria-label="nextImage"
           disabled
         >
           ›
@@ -114,10 +117,11 @@
           class="media-viewer-open"
           disabled
         >
-          在系统照片中打开
+          <span data-i18n="openInPhotos">Open in system photos app</span>
         </button>
       </div>
     </div>
+    <script src="i18n.js"></script>
     <script src="renderer.js" type="module"></script>
   </body>
 </html>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1,3 +1,6 @@
+const { t, translateDocument } = window.ImageViewerI18n;
+translateDocument();
+
 const directoryListEl = document.getElementById('directory-list');
 const mediaGridEl = document.getElementById('media-grid');
 const mediaScrollContainer = document.querySelector('.media-panel-content');
@@ -79,7 +82,7 @@ render();
 
 mediaApi?.getDemoData?.().then((demo) => {
   if (!demo) return;
-  showMessage('演示模式仅展示虚拟目录元数据，不会读取或写入媒体文件。', false);
+  showMessage(t('demoNotice'), false);
   updateState({ ...demo, selectedPath: demo.leaves[0]?.path ?? null });
 });
 
@@ -143,7 +146,7 @@ document.addEventListener('keydown', handleMediaViewerKeydown, true);
 
 if (!mediaApi?.selectRoot) {
   selectRootButton.disabled = true;
-  selectRootButton.textContent = '选择目录（不可用）';
+  selectRootButton.textContent = t('selectDirectoryUnavailable');
   console.warn('mediaApi.selectRoot is unavailable.');
 } else {
   selectRootButton.addEventListener('click', async () => {
@@ -248,7 +251,7 @@ function render() {
 
 function renderRoot() {
   if (!currentState.root) {
-    currentRootEl.textContent = '尚未选择目录';
+    currentRootEl.textContent = t('noDirectorySelected');
   } else {
     currentRootEl.textContent = currentState.root;
   }
@@ -265,8 +268,8 @@ function renderSavedTags() {
     const empty = document.createElement('span');
     empty.className = 'tag-empty';
     empty.textContent = mediaApi?.getRootTags
-      ? '尚未保存任何目录。'
-      : '无法获取已保存的目录。';
+      ? t('noSavedDirectories')
+      : t('savedDirectoriesUnavailable');
     tagListEl.appendChild(empty);
     return;
   }
@@ -287,7 +290,7 @@ function renderSavedTags() {
     const removeButton = document.createElement('button');
     removeButton.className = 'tag-remove-button';
     removeButton.type = 'button';
-    removeButton.setAttribute('aria-label', `移除 ${label}`);
+    removeButton.setAttribute('aria-label', t('removeItem', { label }));
     removeButton.textContent = '×';
     removeButton.addEventListener('click', (event) =>
       handleSavedTagRemoval(event, tag, label)
@@ -310,7 +313,7 @@ function renderTagFilters() {
   if (!currentState.leaves.length) {
     const empty = document.createElement('span');
     empty.className = 'filter-tag-empty';
-    empty.textContent = '选择目录后会自动生成标签。';
+    empty.textContent = t('tagsAfterSelection');
     filterTagListEl.appendChild(empty);
     restoreFilterTagScroll(previousScrollTop);
     return;
@@ -329,7 +332,7 @@ function renderTagFilters() {
   if (!currentState.derivedTags.length) {
     const empty = document.createElement('span');
     empty.className = 'filter-tag-empty';
-    empty.textContent = '未发现重复关键词，暂无生成标签。';
+    empty.textContent = t('noGeneratedTags');
     filterTagListEl.appendChild(empty);
     restoreFilterTagScroll(previousScrollTop);
     return;
@@ -338,7 +341,7 @@ function renderTagFilters() {
   const buttonsContainer = document.createElement('div');
   buttonsContainer.className = 'filter-tag-button-group';
 
-  const allButton = createFilterButton('全部', null, currentState.activeTag == null);
+  const allButton = createFilterButton(t('all'), null, currentState.activeTag == null);
   const allEntry = document.createElement('div');
   allEntry.className = 'filter-tag-entry';
   allEntry.appendChild(allButton);
@@ -356,7 +359,7 @@ function renderTagFilters() {
   if (!filteredTags.length) {
     const empty = document.createElement('span');
     empty.className = 'filter-tag-empty';
-    empty.textContent = '没有找到匹配的标签。';
+    empty.textContent = t('noMatchingTags');
     filterTagListEl.appendChild(empty);
   }
 
@@ -421,8 +424,8 @@ function createFilterTagEntry(tag) {
   const excludeButton = document.createElement('button');
   excludeButton.type = 'button';
   excludeButton.className = 'filter-tag-exclude-button';
-  excludeButton.setAttribute('aria-label', `排除标签 ${tag.label}`);
-  excludeButton.title = '从标签列表中排除此标签';
+  excludeButton.setAttribute('aria-label', t('excludeTag', { label: tag.label }));
+  excludeButton.title = t('excludeTagTitle');
   excludeButton.textContent = '×';
   excludeButton.addEventListener('click', (event) =>
     handleExcludeTag(event, tag)
@@ -529,7 +532,7 @@ function createExcludedTagSettings() {
 
   const title = document.createElement('h4');
   title.className = 'excluded-tag-title';
-  title.textContent = '标签排除';
+  title.textContent = t('tagExclusions');
   header.appendChild(title);
 
   const excluded = Array.isArray(currentState.excludedTags)
@@ -549,11 +552,11 @@ function createExcludedTagSettings() {
     String(Boolean(currentState.excludedTagPanelExpanded))
   );
   toggleButton.textContent = currentState.excludedTagPanelExpanded
-    ? '收起'
-    : '展开';
+    ? t('collapse')
+    : t('expand');
   toggleButton.setAttribute(
     'aria-label',
-    currentState.excludedTagPanelExpanded ? '收起标签排除设置' : '展开标签排除设置'
+    currentState.excludedTagPanelExpanded ? t('collapseTagExclusions') : t('expandTagExclusions')
   );
   toggleButton.addEventListener('click', (event) => {
     event.preventDefault();
@@ -581,7 +584,7 @@ function createExcludedTagSettings() {
 
   const help = document.createElement('p');
   help.className = 'excluded-tag-help';
-  help.textContent = '被排除的标签不会在筛选列表中显示，子文件夹也不会按照这些标签分组。';
+  help.textContent = t('excludedTagsHelp');
   body.appendChild(help);
 
   const form = document.createElement('form');
@@ -591,14 +594,14 @@ function createExcludedTagSettings() {
   const input = document.createElement('input');
   input.type = 'text';
   input.className = 'excluded-tag-input';
-  input.placeholder = '输入要排除的标签';
-  input.setAttribute('aria-label', '输入要排除的标签');
+  input.placeholder = t('excludedTagInput');
+  input.setAttribute('aria-label', t('excludedTagInput'));
   form.appendChild(input);
 
   const addButton = document.createElement('button');
   addButton.type = 'submit';
   addButton.className = 'excluded-tag-add-button';
-  addButton.textContent = '添加';
+  addButton.textContent = t('add');
   form.appendChild(addButton);
 
   body.appendChild(form);
@@ -606,7 +609,7 @@ function createExcludedTagSettings() {
   if (!excluded.length) {
     const empty = document.createElement('span');
     empty.className = 'excluded-tag-empty';
-    empty.textContent = '尚未排除任何标签。';
+    empty.textContent = t('noExcludedTags');
     body.appendChild(empty);
     container.appendChild(body);
     return container;
@@ -637,7 +640,7 @@ function createExcludedTagSettings() {
     const restoreButton = document.createElement('button');
     restoreButton.type = 'button';
     restoreButton.className = 'excluded-tag-restore-button';
-    restoreButton.textContent = '恢复';
+    restoreButton.textContent = t('restore');
     restoreButton.addEventListener('click', () =>
       handleRestoreExcludedTag(item.id)
     );
@@ -664,12 +667,12 @@ function renderDirectoryList() {
     if (currentState.activeTag) {
       const label = getActiveTagLabel();
       emptyMessage.textContent = label
-        ? `没有找到与标签“${label}”匹配的文件夹。`
-        : '没有找到匹配所选标签的文件夹。';
+        ? t('noFoldersForTag', { label })
+        : t('noFoldersForSelection');
     } else {
       emptyMessage.textContent = currentState.root
-        ? '所选目录中没有媒体文件。'
-        : '请选择一个目录开始。';
+        ? t('noMediaInSelection')
+        : t('selectDirectoryToStart');
     }
     directoryListEl.appendChild(emptyMessage);
     directoryListEl.scrollTop = 0;
@@ -691,7 +694,7 @@ function renderDirectoryList() {
       void openDirectoryInExplorer(leaf.path);
     });
 
-    item.title = '右键可在系统文件管理器中打开该目录';
+    item.title = t('folderContextHint');
 
     const name = document.createElement('span');
     name.className = 'directory-name';
@@ -731,7 +734,7 @@ function updateOpenDirectoryButton(leaf) {
     openDirectoryButton.title = leaf.path;
     openDirectoryButton.setAttribute(
       'aria-label',
-      `在资源管理器中打开 ${leaf.displayPath || leaf.path}`
+      t('openNamedDirectory', { path: leaf.displayPath || leaf.path })
     );
   } else {
     openDirectoryButton.disabled = true;
@@ -750,12 +753,12 @@ async function openDirectoryInExplorer(directoryPath) {
     try {
       const result = await mediaApi.openDirectory(directoryPath);
       if (result && result.success === false) {
-        throw new Error(result.error || '无法打开目录');
+        throw new Error(result.error || t('directoryOpenFailed'));
       }
       return;
     } catch (error) {
       console.error('Failed to open directory', error);
-      window.alert('无法在系统文件管理器中打开该目录，请确认路径是否存在。');
+      window.alert(t('directoryOpenAlert'));
       return;
     }
   }
@@ -763,13 +766,13 @@ async function openDirectoryInExplorer(directoryPath) {
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(directoryPath);
-      window.alert(`已复制目录路径：\n${directoryPath}`);
+      window.alert(t('directoryPathCopied', { path: directoryPath }));
     } else {
-      window.prompt('请复制目录路径：', directoryPath);
+      window.prompt(t('copyDirectoryPath'), directoryPath);
     }
   } catch (error) {
     console.error('Failed to copy directory path', error);
-    window.prompt('请复制目录路径：', directoryPath);
+    window.prompt(t('copyDirectoryPath'), directoryPath);
   }
 }
 
@@ -782,14 +785,14 @@ function formatSavedTagLabel(tag) {
     const lastSegment = segments.length ? segments[segments.length - 1] : '';
     return lastSegment || tag.path;
   }
-  return '已保存的目录';
+  return t('savedDirectory');
 }
 
 async function handleSavedTagSelection(tag) {
   if (!mediaApi?.scanDirectory) {
     return;
   }
-  showMediaPendingProgress('正在加载已保存的目录…');
+  showMediaPendingProgress(t('loadingSavedDirectory'));
 
   try {
     const result = await mediaApi.scanDirectory(tag.path);
@@ -819,7 +822,7 @@ async function handleSavedTagRemoval(event, tag, label) {
     return;
   }
 
-  const confirmed = window.confirm(`要移除已保存的目录“${label}”吗？`);
+  const confirmed = window.confirm(t('removeSavedDirectoryConfirm', { label }));
   if (!confirmed) {
     return;
   }
@@ -837,7 +840,7 @@ function renderMedia() {
 
   if (!selectedPath) {
     updateOpenDirectoryButton(null);
-    mediaHeadingEl.textContent = '媒体';
+    mediaHeadingEl.textContent = t('media');
     mediaCountEl.textContent = '';
     abortMediaRender();
     resetMediaView();
@@ -848,7 +851,7 @@ function renderMedia() {
   const leaf = currentState.leaves.find((item) => item.path === selectedPath);
   if (!leaf) {
     updateOpenDirectoryButton(null);
-    mediaHeadingEl.textContent = '媒体';
+    mediaHeadingEl.textContent = t('media');
     mediaCountEl.textContent = '';
     abortMediaRender();
     resetMediaView();
@@ -860,7 +863,7 @@ function renderMedia() {
 
   const itemCount = Number.isFinite(leaf.mediaFileCount) ? leaf.mediaFileCount : 0;
   mediaHeadingEl.textContent = leaf.displayPath;
-  mediaCountEl.textContent = `${itemCount} 个项目`;
+  mediaCountEl.textContent = t('itemCount', { count: itemCount });
 
   const needsReload =
     mediaSession.path !== leaf.path || mediaSession.sourceVersion !== currentState.leavesVersion;
@@ -877,13 +880,13 @@ function renderMedia() {
   if (!itemCount) {
     const emptyMessage = document.createElement('p');
     emptyMessage.className = 'empty-state';
-    emptyMessage.textContent = '该文件夹中没有媒体文件。';
+    emptyMessage.textContent = t('noMediaInFolder');
     mediaGridEl.appendChild(emptyMessage);
     return;
   }
 
   if (!mediaApi?.listMediaFiles) {
-    showMediaLoadError('当前版本无法加载媒体文件。');
+    showMediaLoadError(t('mediaUnavailable'));
     return;
   }
 
@@ -937,7 +940,7 @@ async function fetchNextMediaChunk(session) {
 
   if (!mediaApi?.listMediaFiles) {
     session.done = true;
-    showMediaLoadError('无法加载媒体文件。');
+    showMediaLoadError(t('mediaLoadFailed'));
     failMediaProgress();
     delete mediaGridEl.dataset.loading;
     mediaRenderAbortController = null;
@@ -960,7 +963,7 @@ async function fetchNextMediaChunk(session) {
     }
     console.error('Failed to load media files', error);
     session.done = true;
-    showMediaLoadError('无法加载媒体文件。');
+    showMediaLoadError(t('mediaLoadFailed'));
     failMediaProgress();
     delete mediaGridEl.dataset.loading;
     mediaRenderAbortController = null;
@@ -976,7 +979,7 @@ async function fetchNextMediaChunk(session) {
 
   if (response?.error) {
     session.done = true;
-    showMediaLoadError(response.error || '无法加载媒体文件。');
+    showMediaLoadError(response.error || t('mediaLoadFailed'));
     failMediaProgress();
     delete mediaGridEl.dataset.loading;
     mediaRenderAbortController = null;
@@ -1006,7 +1009,7 @@ async function fetchNextMediaChunk(session) {
     if (!hasMore && session.renderedCount === 0) {
       const emptyMessage = document.createElement('p');
       emptyMessage.className = 'empty-state';
-      emptyMessage.textContent = '该文件夹中没有媒体文件。';
+      emptyMessage.textContent = t('noMediaInFolder');
       mediaGridEl.appendChild(emptyMessage);
     }
 
@@ -1079,7 +1082,7 @@ async function renderMediaChunk(files, totalCount, requestId) {
 function showMediaLoadError(message) {
   const emptyMessage = document.createElement('p');
   emptyMessage.className = 'empty-state';
-  emptyMessage.textContent = message || '无法加载媒体文件。';
+  emptyMessage.textContent = message || t('mediaLoadFailed');
   mediaGridEl.appendChild(emptyMessage);
 }
 
@@ -1391,8 +1394,8 @@ function createTagFilterControls() {
   searchInput.type = 'search';
   searchInput.id = 'tag-search-input';
   searchInput.className = 'filter-tag-search-input';
-  searchInput.placeholder = '搜索标签';
-  searchInput.setAttribute('aria-label', '搜索标签');
+  searchInput.placeholder = t('searchTags');
+  searchInput.setAttribute('aria-label', t('searchTags'));
   const searchValue =
     typeof tagSearchDraft === 'string'
       ? tagSearchDraft
@@ -1406,7 +1409,7 @@ function createTagFilterControls() {
   const confirmButton = document.createElement('button');
   confirmButton.type = 'submit';
   confirmButton.className = 'filter-tag-search-submit';
-  confirmButton.textContent = '确认';
+  confirmButton.textContent = t('confirm');
 
   searchForm.appendChild(searchInput);
   searchForm.appendChild(confirmButton);
@@ -1419,11 +1422,11 @@ function createTagFilterControls() {
   const sortSelect = document.createElement('select');
   sortSelect.id = 'tag-sort-select';
   sortSelect.className = 'filter-tag-sort-select';
-  sortSelect.setAttribute('aria-label', '标签排序');
+  sortSelect.setAttribute('aria-label', t('tagSort'));
 
   const options = [
-    { value: TAG_SORT_MODES.ALPHABETICAL, label: '按首字母' },
-    { value: TAG_SORT_MODES.FREQUENCY, label: '按数量' },
+    { value: TAG_SORT_MODES.ALPHABETICAL, label: t('sortAlphabetically') },
+    { value: TAG_SORT_MODES.FREQUENCY, label: t('sortByCount') },
   ];
 
   options.forEach((option) => {
@@ -1543,7 +1546,7 @@ function showMediaPendingProgress(message) {
   }
 
   if (mediaProgressLabelEl) {
-    mediaProgressLabelEl.textContent = message || '正在加载…';
+    mediaProgressLabelEl.textContent = message || t('loading');
   }
 }
 
@@ -1561,7 +1564,7 @@ function updateMediaProgress(loaded) {
   }
 
   if (mediaProgressLabelEl) {
-    mediaProgressLabelEl.textContent = `加载中 ${clampedLoaded} / ${total}`;
+    mediaProgressLabelEl.textContent = t('loadingProgress', { loaded: clampedLoaded, total });
   }
 }
 
@@ -1574,7 +1577,7 @@ function finishMediaProgress() {
   updateMediaProgress(mediaProgressTotalCount);
 
   if (mediaProgressLabelEl) {
-    mediaProgressLabelEl.textContent = '加载完成';
+    mediaProgressLabelEl.textContent = t('loadingComplete');
   }
 
   mediaProgressEl.dataset.state = 'complete';
@@ -1596,7 +1599,7 @@ function failMediaProgress() {
   if (mediaProgressTotalCount > 0) {
     updateMediaProgress(mediaProgressTotalCount);
     if (mediaProgressLabelEl) {
-      mediaProgressLabelEl.textContent = '加载失败';
+      mediaProgressLabelEl.textContent = t('loadingFailed');
     }
     mediaProgressEl.dataset.state = 'error';
     if (mediaProgressHideTimer) {
@@ -1754,7 +1757,7 @@ function createMediaCard(file, signal, index) {
     const badge = document.createElement('span');
     badge.className = 'media-badge media-badge-video';
     badge.textContent = '🎬';
-    badge.title = '视频';
+    badge.title = t('video');
     badge.setAttribute('aria-hidden', 'true');
     card.appendChild(badge);
   }
@@ -1769,11 +1772,11 @@ function createMediaCard(file, signal, index) {
   const meta = document.createElement('span');
   meta.className = 'media-meta';
   if (file?.type === 'video') {
-    meta.textContent = '视频';
+    meta.textContent = t('video');
   } else if (file?.type === 'image') {
-    meta.textContent = '图片';
+    meta.textContent = t('image');
   } else {
-    meta.textContent = String(file?.type ?? '').toUpperCase() || '媒体';
+    meta.textContent = String(file?.type ?? '').toUpperCase() || t('media');
   }
 
   info.appendChild(name);
@@ -1783,7 +1786,7 @@ function createMediaCard(file, signal, index) {
   if (ratingValue !== undefined && ratingValue !== null && ratingValue !== '') {
     const rating = document.createElement('span');
     rating.className = 'media-rating';
-    rating.textContent = `评分：${ratingValue}`;
+    rating.textContent = t('rating', { rating: ratingValue });
     info.appendChild(rating);
   }
 
@@ -2183,7 +2186,7 @@ function createWorkerImageLoader() {
       return;
     }
 
-    reject(new Error('未知的图片加载结果'));
+    reject(new Error(t('unknownImageResult')));
   });
 
   worker.addEventListener('error', (event) => {
@@ -2192,7 +2195,7 @@ function createWorkerImageLoader() {
 
   const load = (url, signal) => {
     if (!url) {
-      return Promise.reject(new Error('缺少图片地址'));
+      return Promise.reject(new Error(t('missingImageUrl')));
     }
 
     if (signal?.aborted) {
@@ -2234,7 +2237,7 @@ function createWorkerImageLoader() {
 function createFallbackImageLoader() {
   const load = (url, signal) => {
     if (!url) {
-      return Promise.reject(new Error('缺少图片地址'));
+      return Promise.reject(new Error(t('missingImageUrl')));
     }
 
     if (signal?.aborted) {
@@ -2266,7 +2269,7 @@ function createFallbackImageLoader() {
 
       image.onerror = (error) => {
         cleanup();
-        reject(error instanceof Error ? error : new Error('图片加载失败'));
+        reject(error instanceof Error ? error : new Error(t('imageLoadFailed')));
       };
 
       if (signal) {

--- a/tests-js/i18n.test.js
+++ b/tests-js/i18n.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const i18n = require('../renderer/i18n');
+
+test('English is the default locale and supports interpolation', () => {
+  assert.equal(i18n.getLocale(), 'en');
+  assert.equal(i18n.t('appTitle'), 'Local Media Browser');
+  assert.equal(i18n.t('itemCount', { count: 12 }), '12 items');
+});
+
+test('English and Simplified Chinese dictionaries contain the same terms', () => {
+  assert.deepEqual(
+    Object.keys(i18n.translations.en).sort(),
+    Object.keys(i18n.translations['zh-CN']).sort(),
+  );
+  assert.equal(i18n.setLocale('zh-CN'), 'zh-CN');
+  assert.equal(i18n.t('appTitle'), '本地媒体浏览器');
+  assert.equal(i18n.t('itemCount', { count: 12 }), '12 个项目');
+});
+
+test('main page declares English and loads translations before the renderer', () => {
+  const html = fs.readFileSync(path.resolve('renderer/index.html'), 'utf8');
+
+  assert.match(html, /<html lang="en">/);
+  assert.match(html, /data-i18n="appTitle">Local Media Browser</);
+  assert.ok(html.indexOf('src="i18n.js"') < html.indexOf('src="renderer.js"'));
+});


### PR DESCRIPTION
### Motivation
- Centralize user-facing strings and add localization support so the UI can display English by default and Simplified Chinese (`zh-CN`).
- Replace hard-coded Chinese strings in the renderer with a translation API to enable runtime locale selection and document translation.
- Provide consistent, localizable error messages from the image loader and make ARIA/tooltip text translatable.

### Description
- Add `renderer/i18n.js` which exposes `t`, `setLocale`, `translateDocument`, `getLocale`, and an `translations` dictionary containing `en` and `zh-CN` entries. 
- Update `renderer/index.html` to declare `lang="en"`, annotate UI elements with `data-i18n` or `data-i18n-aria-label`, and include `i18n.js` before `renderer.js` so translations load first. 
- Replace many hard-coded strings in `renderer/renderer.js` with calls to `t(...)` and call `translateDocument()` at startup to localize static DOM content; also update ARIA labels, titles, and progress messages. 
- Normalize worker/loader error messages in `renderer/image-loader.js` to English keys that map to `i18n` templates for consistency. 
- Add unit tests in `tests-js/i18n.test.js` to validate default locale, interpolation, dictionary parity between `en` and `zh-CN`, and that `index.html` is set up to load translations before the renderer.

### Testing
- Ran the new i18n unit tests in `tests-js/i18n.test.js` with the Node test runner (e.g. `node --test tests-js/i18n.test.js`) and they passed. 
- Verified the generated `renderer/index.html` contains `<html lang="en">` and that `i18n.js` appears before `renderer.js` as asserted by the tests. 
- Performed automated checks that `i18n.t` interpolation returns expected strings for both `en` and `zh-CN` and that `setLocale('zh-CN')` switches locale successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71939446b48331a5d330821102bd2f)