### PR TITLE
文档：同步 v0.1.1 发布证据

### DIFF
--- a/docs/maintenance-evidence.md
+++ b/docs/maintenance-evidence.md
@@ -10,12 +10,12 @@
 | 条件 | 状态 | 可核验证据 | 结论 |
 | --- | --- | --- | --- |
 | 许可证已确认 | 满足 | [MIT License](../LICENSE)、[许可证分析](license-analysis.md)、[README 许可证说明](../README.md#许可证) | 唯一版权所有者已书面确认个人权属与 MIT 授权，元数据已同步。 |
-| 正式 Release 可下载 | 满足 | [GitHub Release v0.1.0](https://github.com/DokutokuGame/ImageViewer/releases/tag/v0.1.0)、[v0.1.0 发布说明](releases/v0.1.0.md) | 已提供 Windows x64 便携包和 SHA-256 文件；项目仍是早期预览阶段。 |
+| 正式 Release 可下载 | 满足 | [GitHub Release v0.1.1](https://github.com/DokutokuGame/ImageViewer/releases/tag/v0.1.1)、[v0.1.1 发布说明](releases/v0.1.1.md) | 已提供 Windows x64 便携包和 SHA-256 文件；项目仍是早期预览阶段。 |
 | CI 稳定 | 暂缺 | [Actions](https://github.com/DokutokuGame/ImageViewer/actions)、[Node 工作流](https://github.com/DokutokuGame/ImageViewer/actions/workflows/node.yml)、[Python 工作流](https://github.com/DokutokuGame/ImageViewer/actions/workflows/python.yml)、[仓库检查](https://github.com/DokutokuGame/ImageViewer/actions/workflows/repository.yml) | 已配置工作流，但尚未记录连续成功观察窗口，不能称为稳定。 |
 | README 完整 | 部分满足 | [README](../README.md) | 已有下载、安装、验证、平台状态、贡献、安全与许可证入口；完整界面验收与跨平台证据仍待补充。 |
-| 最近 30 天有维护记录 | 满足 | [Pull requests](https://github.com/DokutokuGame/ImageViewer/pulls?q=is%3Apr+updated%3A%3E%3D2026-07-05)、[提交记录](https://github.com/DokutokuGame/ImageViewer/commits) | 2026-08-03 有合并与发布准备维护记录。 |
+| 最近 30 天有维护记录 | 满足 | [Pull requests](https://github.com/DokutokuGame/ImageViewer/pulls?q=is%3Apr+updated%3A%3E%3D2026-07-05)、[提交记录](https://github.com/DokutokuGame/ImageViewer/commits) | 2026-08-04 有合并与发布维护记录。 |
 
-**当前发布决定：已发布 v0.1.0 早期预览版。** 该决定不代表稳定性或跨平台承诺，后续以 Release 和验证记录为准。
+**当前发布决定：已发布 v0.1.1 早期预览版。** 该决定不代表稳定性或跨平台承诺，后续以 Release 和验证记录为准。
 
 ## 周报起点与记录规则
 
@@ -39,8 +39,8 @@
 
 - Star：暂缺（更新时从 [仓库主页](https://github.com/DokutokuGame/ImageViewer) 读取并注明核验时间）；
 - Fork：暂缺（更新时从 [Forks 页面](https://github.com/DokutokuGame/ImageViewer/forks) 读取并注明核验时间）；
-- 正式 Release：1；当前为 [v0.1.0](https://github.com/DokutokuGame/ImageViewer/releases/tag/v0.1.0)；
-- Release 下载：暂缺；应从 v0.1.0 的 asset 数据核对并注明时间，Actions artifact 不计下载量；
+- 正式 Release：2；当前为 [v0.1.1](https://github.com/DokutokuGame/ImageViewer/releases/tag/v0.1.1)；
+- Release 下载：暂缺；应从 v0.1.1 的 asset 数据核对并注明时间，Actions artifact 不计下载量；
 - 外部 Issue：暂缺；须逐项检查 [Issues](https://github.com/DokutokuGame/ImageViewer/issues?q=is%3Aissue) 的作者身份后统计；
 - 外部 PR：暂缺；须逐项检查 [Pull requests](https://github.com/DokutokuGame/ImageViewer/pulls?q=is%3Apr) 的作者身份后统计；
 - 其他外部反馈：0；目前没有链接到可公开核验的讨论、Issue 或 Release 反馈。
@@ -60,6 +60,7 @@ Codex 参与不表述为“自动维护”。每条记录必须同时包含具�
 | 2026-08-03 | [PR #16：首次运行体验](https://github.com/DokutokuGame/ImageViewer/pull/16) | 统一入口、错误提示、演示模式与 README | 维护者按 README 从干净检出复现，并人工检查首次启动及错误文案后决定；未留公开记录的人工步骤不宣称已完成 | [PR checks](https://github.com/DokutokuGame/ImageViewer/pull/16/checks)；平台人工验证见 README | 合并 PR 的仓库维护者（以 PR 事件记录为准） |
 | 2026-08-03 | [PR #17：Windows 候选包](https://github.com/DokutokuGame/ImageViewer/pull/17) | 增加便携候选包、SHA-256 和干净解压验证 | 维护者复核包内容、校验脚本、工作流日志和候选/正式发布边界后决定是否合并 | [PR checks](https://github.com/DokutokuGame/ImageViewer/pull/17/checks)、[Windows release package](https://github.com/DokutokuGame/ImageViewer/actions/workflows/windows-release.yml) | 合并 PR 的仓库维护者（以 PR 事件记录为准） |
 | 2026-08-03 | [PR #21：v0.1.0 高风险依赖修复](https://github.com/DokutokuGame/ImageViewer/pull/21) | 升级 Electron、收紧渲染进程权限，并补齐发布包许可证通知与验证 | 维护者复核依赖变更、窗口安全配置、制品内容和 Windows 启动冒烟测试后决定是否合并 | [PR checks](https://github.com/DokutokuGame/ImageViewer/pull/21/checks)、[Windows release package](https://github.com/DokutokuGame/ImageViewer/actions/workflows/windows-release.yml) | 合并 PR 的仓库维护者（以 PR 事件记录为准） |
+| 2026-08-04 | [PR #25：v0.1.1 发布准备](https://github.com/DokutokuGame/ImageViewer/pull/25) | 同步版本、双语下载入口、Windows 制品名与发布说明 | 维护者核对版本一致性、国际化测试、制品内容、校验值和启动冒烟结果后决定是否合并 | [PR checks](https://github.com/DokutokuGame/ImageViewer/pull/25/checks)、[v0.1.1 Release](https://github.com/DokutokuGame/ImageViewer/releases/tag/v0.1.1) | 合并并发布 Release 的仓库维护者（以 GitHub 事件记录为准） |
 
 表中“人工复核方式”是合并前应执行且应在 GitHub 留痕的核验标准；它不是对未公开操作的
 追认。汇总时只保留能由 Review、评论、check 或维护记录证明已完成的部分。


### PR DESCRIPTION
## 变更内容

- 将当前可下载 Release 更新为 v0.1.1
- 将正式 Release 数量更新为 2
- 同步最近维护日期和下载统计核验入口
- 记录 PR #25 与 v0.1.1 Release 的验证证据

## 验证

- Markdown diff 人工检查
- `git diff --check` 通过

该提交发生在 v0.1.1 tag 之后，只更新维护证据，不改变已发布二进制或 tag。